### PR TITLE
Add Destination outputs for AJS-37 Viggen

### DIFF
--- a/Scripts/DCS-BIOS/lib/AJS37.lua
+++ b/Scripts/DCS-BIOS/lib/AJS37.lua
@@ -499,4 +499,36 @@ defineString("AJS37_NAV_INDICATOR_DATA_6", getAJS37NavIndicator6, 1, "Navigation
 defineIndicatorLight("HUVUDVARNING_L", 444, "Error Panel", "Master Caution Light left (red)")
 defineIndicatorLight("HUVUDVARNING_R", 445, "Error Panel", "Master Caution Light right (red)")
 
+local function getAJS37DestIndicator1()
+	local li = list_indication(1)
+	local m = li:gmatch("-----------------------------------------\n([^\n]+)\n([^\n]*)\n")
+	while true do
+		local name, value = m()
+        if not name then break end
+		if name == "Dest1"
+			then
+			return value:sub(1)
+		end
+    end
+return "X"
+end
+ 
+defineString("AJS37_DEST_INDICATOR_DATA_1", getAJS37DestIndicator1, 1, "Destination", "Destination Data Digit 1")
+
+local function getAJS37DestIndicator2()
+	local li = list_indication(1)
+	local m = li:gmatch("-----------------------------------------\n([^\n]+)\n([^\n]*)\n")
+	while true do
+		local name, value = m()
+        if not name then break end
+		if name == "Dest2"
+			then
+			return value:sub(1)
+		end
+    end
+return "X"
+end
+ 
+defineString("AJS37_DEST_INDICATOR_DATA_2", getAJS37DestIndicator2, 1, "Destination", "Destination Data Digit 2")
+
 BIOS.protocol.endModule()


### PR DESCRIPTION
I haven't tested fully, but the first character seems to be odd - in a situation where the panel displayed "LB 1", the first character was returned as "O" (I suspect something to do with Heatblur using a fancy font to render the stylized LB).