### PR TITLE
Add AH-64D EUFD display lines

### DIFF
--- a/Scripts/DCS-BIOS/BIOS.lua
+++ b/Scripts/DCS-BIOS/BIOS.lua
@@ -24,6 +24,7 @@ dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\Protocol.lua]])
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\MetadataEnd.lua]])
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\MetadataStart.lua]])
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\CommonData.lua]])
+dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\TextDisplay.lua]])
 ----------------------------------------------------------------------------Modules Start------------------------------------
 -- Following text : Example (case sensitive!) : -- ID = x, ProperName = <pretty name>
 -- is used by DCSFlightpanels GUI to pick up DCS-BIOS modules

--- a/Scripts/DCS-BIOS/lib/AH-64D.lua
+++ b/Scripts/DCS-BIOS/lib/AH-64D.lua
@@ -20,6 +20,8 @@ local defineString = BIOS.util.defineString
 local defineIntegerFromGetter = BIOS.util.defineIntegerFromGetter
 local define3PosTumb = BIOS.util.define3PosTumb
 
+local getDisplayLines = TextDisplay.GetDisplayLines
+
 --Functions
 local function parse_ku(indicator_id)
 	local ku = parse_indication(indicator_id)
@@ -397,6 +399,61 @@ definePushButton("CPG_KU_ENT", 30, 3006, 212, "CPG Keyboard Unit", "Gunner Keybo
 definePotentiometer("CPG_KU_BRT", 30, 3050, 621, {0, 1}, "CPG Keyboard Unit", "Gunner Scratchpad Keyboard Brightness Knob")
    
 -- Enhanced Up-Front Display
+local JSON = loadfile([[Scripts\JSON.lua]])()
+local eufd_indicator_data_file = io.open(lfs.writedir()..[[Scripts\DCS-BIOS\lib\EUFD.json]], "r")
+local eufd_indicator_data = JSON:decode(eufd_indicator_data_file:read("*a"))
+eufd_indicator_data_file:close()
+eufd_indicator_data_file = nil
+
+local LINE_LEN = 56
+
+local function parse_eufd(indicator_id)
+	local dcs_eufd = parse_indication(indicator_id)
+	-- todo: return different page based on the actual page
+	return getDisplayLines(dcs_eufd, LINE_LEN, 14, eufd_indicator_data, function() return "MAIN" end)
+end
+
+local plt_EUFD = {}
+local cpg_EUFD = {}
+
+moduleBeingDefined.exportHooks[#moduleBeingDefined.exportHooks+1] = function()
+	plt_EUFD = parse_eufd(17)
+end
+
+moduleBeingDefined.exportHooks[#moduleBeingDefined.exportHooks+1] = function()
+	cpg_EUFD = parse_eufd(18)
+end
+
+defineString("PLT_EUFD_LINE1", function() return plt_EUFD[1] end, LINE_LEN, "PLT Up-Front Display", "Pilot Up-Front Display Line 1")
+defineString("PLT_EUFD_LINE2", function() return plt_EUFD[2] end, LINE_LEN, "PLT Up-Front Display", "Pilot Up-Front Display Line 2")
+defineString("PLT_EUFD_LINE3", function() return plt_EUFD[3] end, LINE_LEN, "PLT Up-Front Display", "Pilot Up-Front Display Line 3")
+defineString("PLT_EUFD_LINE4", function() return plt_EUFD[4] end, LINE_LEN, "PLT Up-Front Display", "Pilot Up-Front Display Line 4")
+defineString("PLT_EUFD_LINE5", function() return plt_EUFD[5] end, LINE_LEN, "PLT Up-Front Display", "Pilot Up-Front Display Line 5")
+defineString("PLT_EUFD_LINE6", function() return plt_EUFD[6] end, LINE_LEN, "PLT Up-Front Display", "Pilot Up-Front Display Line 6")
+defineString("PLT_EUFD_LINE7", function() return plt_EUFD[7] end, LINE_LEN, "PLT Up-Front Display", "Pilot Up-Front Display Line 7")
+defineString("PLT_EUFD_LINE8", function() return plt_EUFD[8] end, LINE_LEN, "PLT Up-Front Display", "Pilot Up-Front Display Line 8")
+defineString("PLT_EUFD_LINE9", function() return plt_EUFD[9] end, LINE_LEN, "PLT Up-Front Display", "Pilot Up-Front Display Line 9")
+defineString("PLT_EUFD_LINE10", function() return plt_EUFD[10] end, LINE_LEN, "PLT Up-Front Display", "Pilot Up-Front Display Line 10")
+defineString("PLT_EUFD_LINE11", function() return plt_EUFD[11] end, LINE_LEN, "PLT Up-Front Display", "Pilot Up-Front Display Line 11")
+defineString("PLT_EUFD_LINE12", function() return plt_EUFD[12] end, LINE_LEN, "PLT Up-Front Display", "Pilot Up-Front Display Line 12")
+defineString("PLT_EUFD_LINE13", function() return plt_EUFD[13] end, LINE_LEN, "PLT Up-Front Display", "Pilot Up-Front Display Line 13")
+defineString("PLT_EUFD_LINE14", function() return plt_EUFD[14] end, LINE_LEN, "PLT Up-Front Display", "Pilot Up-Front Display Line 14")
+
+defineString("CPG_EUFD_LINE1", function() return cpg_EUFD[1] end, LINE_LEN, "CPG Up-Front Display", "Gunner Up-Front Display Line 1")
+defineString("CPG_EUFD_LINE2", function() return cpg_EUFD[2] end, LINE_LEN, "CPG Up-Front Display", "Gunner Up-Front Display Line 2")
+defineString("CPG_EUFD_LINE3", function() return cpg_EUFD[3] end, LINE_LEN, "CPG Up-Front Display", "Gunner Up-Front Display Line 3")
+defineString("CPG_EUFD_LINE4", function() return cpg_EUFD[4] end, LINE_LEN, "CPG Up-Front Display", "Gunner Up-Front Display Line 4")
+defineString("CPG_EUFD_LINE5", function() return cpg_EUFD[5] end, LINE_LEN, "CPG Up-Front Display", "Gunner Up-Front Display Line 5")
+defineString("CPG_EUFD_LINE6", function() return cpg_EUFD[6] end, LINE_LEN, "CPG Up-Front Display", "Gunner Up-Front Display Line 6")
+defineString("CPG_EUFD_LINE7", function() return cpg_EUFD[7] end, LINE_LEN, "CPG Up-Front Display", "Gunner Up-Front Display Line 7")
+defineString("CPG_EUFD_LINE8", function() return cpg_EUFD[8] end, LINE_LEN, "CPG Up-Front Display", "Gunner Up-Front Display Line 8")
+defineString("CPG_EUFD_LINE9", function() return cpg_EUFD[9] end, LINE_LEN, "CPG Up-Front Display", "Gunner Up-Front Display Line 9")
+defineString("CPG_EUFD_LINE10", function() return cpg_EUFD[10] end, LINE_LEN, "CPG Up-Front Display", "Gunner Up-Front Display Line 10")
+defineString("CPG_EUFD_LINE11", function() return cpg_EUFD[11] end, LINE_LEN, "CPG Up-Front Display", "Gunner Up-Front Display Line 11")
+defineString("CPG_EUFD_LINE12", function() return cpg_EUFD[12] end, LINE_LEN, "CPG Up-Front Display", "Gunner Up-Front Display Line 12")
+defineString("CPG_EUFD_LINE13", function() return cpg_EUFD[13] end, LINE_LEN, "CPG Up-Front Display", "Gunner Up-Front Display Line 13")
+defineString("CPG_EUFD_LINE14", function() return cpg_EUFD[14] end, LINE_LEN, "CPG Up-Front Display", "Gunner Up-Front Display Line 14")
+
 defineSpringloaded_3_pos_tumb("PLT_EUFD_WCA", 48, 3002, 3001, 271, "PLT Up-Front Display", "Pilot Up-Front Display WCA Rocker Switch")
 defineSpringloaded_3_pos_tumb("PLT_EUFD_IDM", 48, 3004, 3003, 270, "PLT Up-Front Display", "Pilot Up-Front Display IDM Rocker Switch")
 defineSpringloaded_3_pos_tumb("PLT_EUFD_RTS", 48, 3006, 3005, 272, "PLT Up-Front Display", "Pilot Up-Front Display RTS Rocker Switch")

--- a/Scripts/DCS-BIOS/lib/CDU.json
+++ b/Scripts/DCS-BIOS/lib/CDU.json
@@ -2,7 +2,7 @@
     "ACCEPT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ"
             ],
             "id": "ACCEPT",
@@ -15,7 +15,7 @@
     "ADI_ATT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "ADI_ATT",
@@ -28,7 +28,7 @@
     "ADI_ATT0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "ADI_ATT0",
@@ -41,7 +41,7 @@
     "ADI_ATT1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "ADI_ATT1",
@@ -54,7 +54,7 @@
     "ALIGN": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "NAV",
                 "INS"
             ],
@@ -68,7 +68,7 @@
     "ALL": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSUPLD"
             ],
             "id": "ALL",
@@ -81,7 +81,7 @@
     "ALL1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSDNLD"
             ],
             "id": "ALL1",
@@ -94,7 +94,7 @@
     "ALL2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSDNLD"
             ],
             "id": "ALL2",
@@ -107,7 +107,7 @@
     "ALM_REQ": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "ALM_REQ",
@@ -120,7 +120,7 @@
     "ALM_REQs": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "ALM_REQs",
@@ -133,7 +133,7 @@
     "ALM_REQs1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "ALM_REQs1",
@@ -146,7 +146,7 @@
     "ALTITUDE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "ALTITUDE",
@@ -159,7 +159,7 @@
     "ALT_ALIGN": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INS"
             ],
             "id": "ALT_ALIGN",
@@ -172,7 +172,7 @@
     "ALT_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "ALT_ST1",
@@ -185,7 +185,7 @@
     "ALT_ST2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "ALT_ST2",
@@ -198,7 +198,7 @@
     "ALT_WIND_TEMP": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "ALT_WIND_TEMP",
@@ -211,7 +211,7 @@
     "ANCHORDIS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "ANCHORDIS1",
@@ -222,7 +222,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "ANCHORDIS1",
@@ -235,7 +235,7 @@
     "ANCHORDIS2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "ANCHORDIS2",
@@ -246,7 +246,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "ANCHORDIS2",
@@ -259,7 +259,7 @@
     "ANCHORDISMH": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "ANCHORDISMH",
@@ -272,7 +272,7 @@
     "ANCHORDMH1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "ANCHORDMH1",
@@ -285,7 +285,7 @@
     "ANCHORDMH2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "ANCHORDMH2",
@@ -298,7 +298,7 @@
     "ANCHORIdent1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "ANCHORIdent1",
@@ -311,7 +311,7 @@
     "ANCHORIdent2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "ANCHORIdent2",
@@ -324,7 +324,7 @@
     "ANCHORIdentEntry": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "ANCHORIdentEntry",
@@ -337,7 +337,7 @@
     "ANCHORMH1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "ANCHORMH1",
@@ -350,7 +350,7 @@
     "ANCHORMH2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "ANCHORMH2",
@@ -363,7 +363,7 @@
     "ANCHORMH3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "ANCHORMH3",
@@ -376,7 +376,7 @@
     "ANCHORNumber1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "ANCHORNumber1",
@@ -389,7 +389,7 @@
     "ANCHORNumber2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "ANCHORNumber2",
@@ -402,7 +402,7 @@
     "ANCHORNumberEntry": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "ANCHORNumberEntry",
@@ -415,7 +415,7 @@
     "ANCHORTOFRMode1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "ANCHORTOFRMode1",
@@ -428,7 +428,7 @@
     "ANCHORTOFRMode2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "ANCHORTOFRMode2",
@@ -441,7 +441,7 @@
     "ANCHORTOFRRotary": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "ANCHORTOFRRotary",
@@ -454,7 +454,7 @@
     "ANCHORTTG1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "ANCHORTTG1",
@@ -465,7 +465,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "ANCHORTTG1",
@@ -478,7 +478,7 @@
     "ANCHORTTG2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "ANCHORTTG2",
@@ -489,7 +489,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "ANCHORTTG2",
@@ -502,7 +502,7 @@
     "ANCHORTTG3": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "ANCHORTTG3",
@@ -513,7 +513,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "ANCHORTTG3",
@@ -526,7 +526,7 @@
     "ANCHOR_PT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "ANCHOR_PT",
@@ -537,7 +537,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPMENU"
             ],
             "id": "ANCHOR_PT",
@@ -550,7 +550,7 @@
     "ANN1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN1",
@@ -563,7 +563,7 @@
     "ANN10": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN10",
@@ -576,7 +576,7 @@
     "ANN11": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN11",
@@ -589,7 +589,7 @@
     "ANN12": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN12",
@@ -602,7 +602,7 @@
     "ANN13": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN13",
@@ -615,7 +615,7 @@
     "ANN14": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN14",
@@ -628,7 +628,7 @@
     "ANN15": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN15",
@@ -641,7 +641,7 @@
     "ANN16": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN16",
@@ -654,7 +654,7 @@
     "ANN17": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN17",
@@ -667,7 +667,7 @@
     "ANN18": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN18",
@@ -680,7 +680,7 @@
     "ANN19": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN19",
@@ -693,7 +693,7 @@
     "ANN2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN2",
@@ -706,7 +706,7 @@
     "ANN20": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN20",
@@ -719,7 +719,7 @@
     "ANN21": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN21",
@@ -732,7 +732,7 @@
     "ANN22": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN22",
@@ -745,7 +745,7 @@
     "ANN23": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN23",
@@ -758,7 +758,7 @@
     "ANN24": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN24",
@@ -771,7 +771,7 @@
     "ANN25": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN25",
@@ -784,7 +784,7 @@
     "ANN26": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN26",
@@ -797,7 +797,7 @@
     "ANN26a": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN26a",
@@ -810,7 +810,7 @@
     "ANN27": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN27",
@@ -823,7 +823,7 @@
     "ANN28": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN28",
@@ -836,7 +836,7 @@
     "ANN29": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN29",
@@ -849,7 +849,7 @@
     "ANN3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN3",
@@ -862,7 +862,7 @@
     "ANN30": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN30",
@@ -875,7 +875,7 @@
     "ANN31": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN31",
@@ -888,7 +888,7 @@
     "ANN32": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN32",
@@ -901,7 +901,7 @@
     "ANN33": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN33",
@@ -914,7 +914,7 @@
     "ANN34": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN34",
@@ -927,7 +927,7 @@
     "ANN35": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN35",
@@ -940,7 +940,7 @@
     "ANN36": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN36",
@@ -953,7 +953,7 @@
     "ANN37": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN37",
@@ -966,7 +966,7 @@
     "ANN38": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN38",
@@ -979,7 +979,7 @@
     "ANN39": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN39",
@@ -992,7 +992,7 @@
     "ANN4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN4",
@@ -1005,7 +1005,7 @@
     "ANN40": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN40",
@@ -1018,7 +1018,7 @@
     "ANN41": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN41",
@@ -1031,7 +1031,7 @@
     "ANN42": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN42",
@@ -1044,7 +1044,7 @@
     "ANN43": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN43",
@@ -1057,7 +1057,7 @@
     "ANN5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN5",
@@ -1070,7 +1070,7 @@
     "ANN6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN6",
@@ -1083,7 +1083,7 @@
     "ANN7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN7",
@@ -1096,7 +1096,7 @@
     "ANN8": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN8",
@@ -1109,7 +1109,7 @@
     "ANN9": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "ANN9",
@@ -1122,7 +1122,7 @@
     "APP": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "APP",
@@ -1135,7 +1135,7 @@
     "AS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSKEYS"
             ],
             "id": "AS",
@@ -1148,7 +1148,7 @@
     "AS_FLAG": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSKEYS"
             ],
             "id": "AS_FLAG",
@@ -1161,7 +1161,7 @@
     "AS_FLAG1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSKEYS"
             ],
             "id": "AS_FLAG1",
@@ -1174,7 +1174,7 @@
     "AS_FLAG2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSKEYS"
             ],
             "id": "AS_FLAG2",
@@ -1187,7 +1187,7 @@
     "ATT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "ATT",
@@ -1200,7 +1200,7 @@
     "ATTRIBCRS0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBCRS0",
@@ -1213,7 +1213,7 @@
     "ATTRIBCRS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBCRS1",
@@ -1226,7 +1226,7 @@
     "ATTRIBCRS2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBCRS2",
@@ -1239,7 +1239,7 @@
     "ATTRIBCRS3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBCRS3",
@@ -1252,7 +1252,7 @@
     "ATTRIBCRS4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBCRS4",
@@ -1265,7 +1265,7 @@
     "ATTRIBCRS5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBCRS5",
@@ -1278,7 +1278,7 @@
     "ATTRIBCRS6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBCRS6",
@@ -1291,7 +1291,7 @@
     "ATTRIBSCS0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBSCS0",
@@ -1304,7 +1304,7 @@
     "ATTRIBSCS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBSCS1",
@@ -1317,7 +1317,7 @@
     "ATTRIBScale": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBScale",
@@ -1330,7 +1330,7 @@
     "ATTRIBScale1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBScale1",
@@ -1343,7 +1343,7 @@
     "ATTRIBScale2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBScale2",
@@ -1356,7 +1356,7 @@
     "ATTRIBScale3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBScale3",
@@ -1369,7 +1369,7 @@
     "ATTRIBSteer": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBSteer",
@@ -1382,7 +1382,7 @@
     "ATTRIBSteer1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBSteer1",
@@ -1395,7 +1395,7 @@
     "ATTRIBSteer2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBSteer2",
@@ -1408,7 +1408,7 @@
     "ATTRIBUTES": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "NAV"
             ],
             "id": "ATTRIBUTES",
@@ -1421,7 +1421,7 @@
     "ATTRIBVNavMode": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBVNavMode",
@@ -1434,7 +1434,7 @@
     "ATTRIBVNavMode1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIBVNavMode1",
@@ -1447,7 +1447,7 @@
     "ATTRIB_CRS_VAL": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "ATTRIB_CRS_VAL",
@@ -1460,7 +1460,7 @@
     "ActiveFP": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "ActiveFP",
@@ -1473,7 +1473,7 @@
     "ActiveFP1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "ActiveFP1",
@@ -1486,7 +1486,7 @@
     "ActiveFP2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "ActiveFP2",
@@ -1499,7 +1499,7 @@
     "ActiveFP3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "ActiveFP3",
@@ -1512,7 +1512,7 @@
     "ActiveFP4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "ActiveFP4",
@@ -1525,7 +1525,7 @@
     "ActiveFP5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "ActiveFP5",
@@ -1538,7 +1538,7 @@
     "AlignMode_BATH": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -1552,7 +1552,7 @@
     "AlignMode_Ground": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -1566,7 +1566,7 @@
     "AlignMode_InFlt": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -1580,7 +1580,7 @@
     "AlignMode_SH": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -1594,7 +1594,7 @@
     "AlignModes": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -1608,7 +1608,7 @@
     "AlignStatus": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -1622,7 +1622,7 @@
     "AlignStatus1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -1636,7 +1636,7 @@
     "AlignStatus2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -1650,7 +1650,7 @@
     "AlignStatusAsterisk": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -1664,7 +1664,7 @@
     "AlignTime": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -1678,7 +1678,7 @@
     "AlignTimeAsterisk": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -1692,7 +1692,7 @@
     "Asterisk": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "1ST_LINE",
                 "1ST_LINE"
             ],
@@ -1706,7 +1706,7 @@
     "BATTERY": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "BATTERY",
@@ -1719,7 +1719,7 @@
     "BATTERYs": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "BATTERYs",
@@ -1732,7 +1732,7 @@
     "BATTERYs1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "BATTERYs1",
@@ -1745,7 +1745,7 @@
     "BBCTL": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "BBCTL",
@@ -1756,7 +1756,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "BITBALL"
             ],
             "id": "BBCTL",
@@ -1769,7 +1769,7 @@
     "BIT_INPR": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "BIT_INPR",
@@ -1782,7 +1782,7 @@
     "BIT_INPRs": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "BIT_INPRs",
@@ -1795,7 +1795,7 @@
     "BIT_INPRs1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "BIT_INPRs1",
@@ -1808,7 +1808,7 @@
     "BIT_TST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSSTAT"
             ],
             "id": "BIT_TST",
@@ -1821,7 +1821,7 @@
     "BLOCK_NUM1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT4",
                 "GPSBIT5"
             ],
@@ -1835,7 +1835,7 @@
     "BLOCK_NUM2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT4",
                 "GPSBIT5"
             ],
@@ -1849,7 +1849,7 @@
     "BLOCK_NUM3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT4",
                 "GPSBIT5"
             ],
@@ -1863,7 +1863,7 @@
     "BLOCK_NUM4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT4",
                 "GPSBIT5"
             ],
@@ -1877,7 +1877,7 @@
     "BLOCK_NUM5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT4",
                 "GPSBIT5"
             ],
@@ -1891,7 +1891,7 @@
     "BLOCK_NUM6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT4",
                 "GPSBIT5"
             ],
@@ -1905,7 +1905,7 @@
     "BLOCK_NUM7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT4",
                 "GPSBIT5"
             ],
@@ -1919,7 +1919,7 @@
     "BLOCK_NUM8": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT4",
                 "GPSBIT5"
             ],
@@ -1933,7 +1933,7 @@
     "BRACKETS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPMENU"
             ],
             "id": "BRACKETS",
@@ -1946,7 +1946,7 @@
     "BRACKETS_EL": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "BRACKETS_EL",
@@ -1959,7 +1959,7 @@
     "BRACKETS_FIRSTCOORD": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "BRACKETS_FIRSTCOORD",
@@ -1972,7 +1972,7 @@
     "BRACKETS_INIT_WP_ID": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "BRACKETS_INIT_WP_ID",
@@ -1985,7 +1985,7 @@
     "BRACKETS_ITEM1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "BRACKETS_ITEM1",
@@ -1998,7 +1998,7 @@
     "BRACKETS_ITEM2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "BRACKETS_ITEM2",
@@ -2011,7 +2011,7 @@
     "BRACKETS_ITEM3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "BRACKETS_ITEM3",
@@ -2024,7 +2024,7 @@
     "BRACKETS_ITEM4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "BRACKETS_ITEM4",
@@ -2037,7 +2037,7 @@
     "BRACKETS_MH_DIS": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "BRACKETS_MH_DIS",
@@ -2050,7 +2050,7 @@
     "BRACKETS_MISC_DATA": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "INS"
             ],
             "id": "BRACKETS_MISC_DATA",
@@ -2063,7 +2063,7 @@
     "BRACKETS_SECONDCOORD": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "BRACKETS_SECONDCOORD",
@@ -2076,7 +2076,7 @@
     "BRACKETS_WPNUM_LTR": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "BRACKETS_WPNUM_LTR",
@@ -2089,7 +2089,7 @@
     "BRACKETS_WPT_NAME": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO",
                 "WAYPT1"
             ],
@@ -2103,7 +2103,7 @@
     "BRANCH1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "BBCTL"
             ],
             "id": "BRANCH1",
@@ -2116,7 +2116,7 @@
     "BVL": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT1"
             ],
             "id": "BVL",
@@ -2129,7 +2129,7 @@
     "BVL_VAL": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT1"
             ],
             "id": "BVL_VAL",
@@ -2142,7 +2142,7 @@
     "BVU": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT1"
             ],
             "id": "BVU",
@@ -2155,7 +2155,7 @@
     "BVU_VAL": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT1"
             ],
             "id": "BVU_VAL",
@@ -2168,7 +2168,7 @@
     "B_ALT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "B_ALT",
@@ -2181,7 +2181,7 @@
     "B_ALT_ST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "B_ALT_ST",
@@ -2194,7 +2194,7 @@
     "B_ALT_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "B_ALT_ST1",
@@ -2207,7 +2207,7 @@
     "B_ALT_VAL": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "B_ALT_VAL",
@@ -2220,7 +2220,7 @@
     "C": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "C",
@@ -2233,7 +2233,7 @@
     "CADC": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "CADC",
@@ -2244,7 +2244,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "CADC",
@@ -2255,7 +2255,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "CADC",
@@ -2266,7 +2266,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "SYS2"
             ],
             "id": "CADC",
@@ -2279,7 +2279,7 @@
     "CADC_SA": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "CADC_SA",
@@ -2292,7 +2292,7 @@
     "CADC_ST0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "CADC_ST0",
@@ -2303,7 +2303,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT",
                 "RESET"
             ],
@@ -2315,7 +2315,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "CADC_ST0",
@@ -2328,7 +2328,7 @@
     "CADC_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "CADC_ST1",
@@ -2339,7 +2339,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "CADC_ST1",
@@ -2352,7 +2352,7 @@
     "CADC_ST2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "CADC_ST2",
@@ -2363,7 +2363,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT",
                 "RESET"
             ],
@@ -2375,7 +2375,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "CADC_ST2",
@@ -2388,7 +2388,7 @@
     "CADC_ST3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "CADC_ST3",
@@ -2399,7 +2399,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT",
                 "RESET"
             ],
@@ -2411,7 +2411,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "CADC_ST3",
@@ -2424,7 +2424,7 @@
     "CADC_ST4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "CADC_ST4",
@@ -2435,7 +2435,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT",
                 "RESET"
             ],
@@ -2447,7 +2447,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "CADC_ST4",
@@ -2460,7 +2460,7 @@
     "CADC_STATUS0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "CADC_STATUS0",
@@ -2473,7 +2473,7 @@
     "CADC_STATUS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "CADC_STATUS1",
@@ -2486,7 +2486,7 @@
     "CADC_STATUS2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "CADC_STATUS2",
@@ -2499,7 +2499,7 @@
     "CADC_STATUS3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "CADC_STATUS3",
@@ -2512,7 +2512,7 @@
     "CBIT1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI4"
             ],
             "id": "CBIT1",
@@ -2525,7 +2525,7 @@
     "CBIT10": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI4"
             ],
             "id": "CBIT10",
@@ -2538,7 +2538,7 @@
     "CBIT11": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI4"
             ],
             "id": "CBIT11",
@@ -2551,7 +2551,7 @@
     "CBIT2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI4"
             ],
             "id": "CBIT2",
@@ -2564,7 +2564,7 @@
     "CBIT3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI4"
             ],
             "id": "CBIT3",
@@ -2577,7 +2577,7 @@
     "CBIT4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI4"
             ],
             "id": "CBIT4",
@@ -2590,7 +2590,7 @@
     "CBIT5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI4"
             ],
             "id": "CBIT5",
@@ -2603,7 +2603,7 @@
     "CBIT6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI4"
             ],
             "id": "CBIT6",
@@ -2616,7 +2616,7 @@
     "CBIT7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI4"
             ],
             "id": "CBIT7",
@@ -2629,7 +2629,7 @@
     "CBIT8": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI4"
             ],
             "id": "CBIT8",
@@ -2642,7 +2642,7 @@
     "CBIT9": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI4"
             ],
             "id": "CBIT9",
@@ -2655,7 +2655,7 @@
     "CDU": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "CDU",
@@ -2666,7 +2666,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "CDU",
@@ -2679,7 +2679,7 @@
     "CDUTEST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST",
@@ -2690,7 +2690,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "SYS2"
             ],
             "id": "CDUTEST",
@@ -2703,7 +2703,7 @@
     "CDUTEST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST1",
@@ -2716,7 +2716,7 @@
     "CDUTEST10": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST10",
@@ -2729,7 +2729,7 @@
     "CDUTEST11": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST11",
@@ -2742,7 +2742,7 @@
     "CDUTEST12": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST12",
@@ -2755,7 +2755,7 @@
     "CDUTEST13": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST13",
@@ -2768,7 +2768,7 @@
     "CDUTEST14": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST14",
@@ -2781,7 +2781,7 @@
     "CDUTEST15": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST15",
@@ -2794,7 +2794,7 @@
     "CDUTEST16": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST16",
@@ -2807,7 +2807,7 @@
     "CDUTEST17": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST17",
@@ -2820,7 +2820,7 @@
     "CDUTEST2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST2",
@@ -2833,7 +2833,7 @@
     "CDUTEST3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST3",
@@ -2846,7 +2846,7 @@
     "CDUTEST4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST4",
@@ -2859,7 +2859,7 @@
     "CDUTEST5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST5",
@@ -2872,7 +2872,7 @@
     "CDUTEST6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST6",
@@ -2885,7 +2885,7 @@
     "CDUTEST7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST7",
@@ -2898,7 +2898,7 @@
     "CDUTEST8": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST8",
@@ -2911,7 +2911,7 @@
     "CDUTEST9": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "CDUTEST9",
@@ -2924,7 +2924,7 @@
     "CDU_LASTE": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DTSUPLD"
             ],
             "id": "CDU_LASTE",
@@ -2937,7 +2937,7 @@
     "CDU_ST0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "CDU_ST0",
@@ -2950,7 +2950,7 @@
     "CDU_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "CDU_ST1",
@@ -2961,7 +2961,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "CDU_ST1",
@@ -2974,7 +2974,7 @@
     "CDU_ST3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "CDU_ST3",
@@ -2985,7 +2985,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "CDU_ST3",
@@ -2998,7 +2998,7 @@
     "CDU_ST4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "CDU_ST4",
@@ -3009,7 +3009,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "CDU_ST4",
@@ -3022,7 +3022,7 @@
     "CDU_STATUS0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "CDU_STATUS0",
@@ -3035,7 +3035,7 @@
     "CDU_STATUS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "CDU_STATUS1",
@@ -3048,7 +3048,7 @@
     "CDU_STATUS2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "CDU_STATUS2",
@@ -3061,7 +3061,7 @@
     "CDU_STATUS3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "CDU_STATUS3",
@@ -3074,7 +3074,7 @@
     "CDU_SYS_ACTION": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "CDU_SYS_ACTION",
@@ -3087,7 +3087,7 @@
     "CHASSIS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "CHASSIS",
@@ -3100,7 +3100,7 @@
     "CHASSIS_STATUS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "CHASSIS_STATUS",
@@ -3113,7 +3113,7 @@
     "CLEAR": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "BBCTL"
             ],
             "id": "CLEAR",
@@ -3126,7 +3126,7 @@
     "CLEAR_SA": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "BBCTL"
             ],
             "id": "CLEAR_SA",
@@ -3139,7 +3139,7 @@
     "CODE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "BITBALL"
             ],
             "id": "CODE",
@@ -3152,7 +3152,7 @@
     "CR_ON_OFF": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "CR_ON_OFF",
@@ -3165,7 +3165,7 @@
     "CR_ON_OFF1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "CR_ON_OFF1",
@@ -3178,7 +3178,7 @@
     "CR_SYMB": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "CR_SYMB",
@@ -3191,7 +3191,7 @@
     "CR_TXT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "CR_TXT",
@@ -3204,7 +3204,7 @@
     "CSCI": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "CSCI",
@@ -3217,7 +3217,7 @@
     "CTD": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POS"
             ],
             "id": "CTD",
@@ -3230,7 +3230,7 @@
     "CTD_VAL": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POS"
             ],
             "id": "CTD_VAL",
@@ -3243,7 +3243,7 @@
     "CoordFormat0": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ",
                 "UPDATE"
             ],
@@ -3257,7 +3257,7 @@
     "CoordFormat1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ",
                 "UPDATE"
             ],
@@ -3271,7 +3271,7 @@
     "CurrFlightPlanLetter0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "1ST_LINE"
             ],
             "id": "CurrFlightPlanLetter0",
@@ -3284,7 +3284,7 @@
     "CurrFlightPlanLetter1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "1ST_LINE"
             ],
             "id": "CurrFlightPlanLetter1",
@@ -3297,7 +3297,7 @@
     "CurrFlightPlanNumber": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "1ST_LINE"
             ],
             "id": "CurrFlightPlanNumber",
@@ -3310,7 +3310,7 @@
     "CurrSteerPointAsterisk": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "1ST_LINE"
             ],
             "id": "CurrSteerPointAsterisk",
@@ -3323,7 +3323,7 @@
     "CurrSteerPointNumber": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "1ST_LINE"
             ],
             "id": "CurrSteerPointNumber",
@@ -3336,7 +3336,7 @@
     "DATA": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSUPLD"
             ],
             "id": "DATA",
@@ -3349,7 +3349,7 @@
     "DATA2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSUPLD"
             ],
             "id": "DATA2",
@@ -3362,7 +3362,7 @@
     "DATA_OFF": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "DATA_OFF",
@@ -3375,7 +3375,7 @@
     "DATA_OFF1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "DATA_OFF1",
@@ -3388,7 +3388,7 @@
     "DATA_PUMP": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "DATA_PUMP",
@@ -3401,7 +3401,7 @@
     "DAY": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "DAY",
@@ -3414,7 +3414,7 @@
     "DAY_DE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "DAY_DE",
@@ -3427,7 +3427,7 @@
     "DAY_TXT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "DAY_TXT",
@@ -3440,7 +3440,7 @@
     "DECR": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "MXLOG"
             ],
             "id": "DECR",
@@ -3453,7 +3453,7 @@
     "DEF_ATT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "DEF_ATT",
@@ -3466,7 +3466,7 @@
     "DEGREE1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "DEGREE1",
@@ -3479,7 +3479,7 @@
     "DEGREE2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "DEGREE2",
@@ -3492,7 +3492,7 @@
     "DEGREE3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "DEGREE3",
@@ -3505,7 +3505,7 @@
     "DIS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ"
             ],
             "id": "DIS",
@@ -3516,7 +3516,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "DIS",
@@ -3527,7 +3527,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "DIS",
@@ -3540,7 +3540,7 @@
     "DISPLAY_TEST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST2"
             ],
             "id": "DISPLAY_TEST",
@@ -3553,7 +3553,7 @@
     "DISPLAY_TEST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST2"
             ],
             "id": "DISPLAY_TEST1",
@@ -3566,7 +3566,7 @@
     "DISPLAY_TEST_VALUES": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST2"
             ],
             "id": "DISPLAY_TEST_VALUES",
@@ -3579,7 +3579,7 @@
     "DIVERT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "NAV"
             ],
             "id": "DIVERT",
@@ -3592,7 +3592,7 @@
     "DIVERTDIV": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTDIV",
@@ -3605,7 +3605,7 @@
     "DIVERTDIV1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTDIV1",
@@ -3618,7 +3618,7 @@
     "DIVERTDIV2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTDIV2",
@@ -3631,7 +3631,7 @@
     "DIVERTDIV3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTDIV3",
@@ -3644,7 +3644,7 @@
     "DIVERTDistance": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTDistance",
@@ -3657,7 +3657,7 @@
     "DIVERTDistance1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTDistance1",
@@ -3670,7 +3670,7 @@
     "DIVERTDistance2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTDistance2",
@@ -3683,7 +3683,7 @@
     "DIVERTDistance3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTDistance3",
@@ -3696,7 +3696,7 @@
     "DIVERTMH": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTMH",
@@ -3709,7 +3709,7 @@
     "DIVERTMH1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTMH1",
@@ -3722,7 +3722,7 @@
     "DIVERTMH2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTMH2",
@@ -3735,7 +3735,7 @@
     "DIVERTMH3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTMH3",
@@ -3748,7 +3748,7 @@
     "DIVERTName": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTName",
@@ -3761,7 +3761,7 @@
     "DIVERTName1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTName1",
@@ -3774,7 +3774,7 @@
     "DIVERTName2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTName2",
@@ -3787,7 +3787,7 @@
     "DIVERTName3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTName3",
@@ -3800,7 +3800,7 @@
     "DIVERTNumber": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTNumber",
@@ -3813,7 +3813,7 @@
     "DIVERTNumber1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTNumber1",
@@ -3826,7 +3826,7 @@
     "DIVERTNumber2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTNumber2",
@@ -3839,7 +3839,7 @@
     "DIVERTNumber3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTNumber3",
@@ -3852,7 +3852,7 @@
     "DIVERTSteer": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTSteer",
@@ -3865,7 +3865,7 @@
     "DIVERTSteer1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTSteer1",
@@ -3878,7 +3878,7 @@
     "DIVERTSteer2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTSteer2",
@@ -3891,7 +3891,7 @@
     "DIVERTSteer3": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTSteer3",
@@ -3904,7 +3904,7 @@
     "DIVERTSteerNOT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTSteerNOT",
@@ -3917,7 +3917,7 @@
     "DIVERTSteerNOT1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTSteerNOT1",
@@ -3930,7 +3930,7 @@
     "DIVERTSteerNOT2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTSteerNOT2",
@@ -3943,7 +3943,7 @@
     "DIVERTSteerNOT3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTSteerNOT3",
@@ -3956,7 +3956,7 @@
     "DIVERTTTG": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTTTG",
@@ -3969,7 +3969,7 @@
     "DIVERTTTG1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTTTG1",
@@ -3982,7 +3982,7 @@
     "DIVERTTTG2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTTTG2",
@@ -3995,7 +3995,7 @@
     "DIVERTTTG3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTTTG3",
@@ -4008,7 +4008,7 @@
     "DIVERTTTG4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTTTG4",
@@ -4021,7 +4021,7 @@
     "DIVERTTTG5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTTTG5",
@@ -4034,7 +4034,7 @@
     "DIVERTTTG6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTTTG6",
@@ -4047,7 +4047,7 @@
     "DIVERTTTG7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTTTG7",
@@ -4060,7 +4060,7 @@
     "DIVERTTTGText": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTTTGText",
@@ -4073,7 +4073,7 @@
     "DIVERTTTGText1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTTTGText1",
@@ -4086,7 +4086,7 @@
     "DIVERTTTGText2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTTTGText2",
@@ -4099,7 +4099,7 @@
     "DIVERTTTGText3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "DIVERTTTGText3",
@@ -4112,7 +4112,7 @@
     "DKI": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "DKI",
@@ -4123,7 +4123,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "DKI",
@@ -4136,7 +4136,7 @@
     "DMH": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "DMH",
@@ -4149,7 +4149,7 @@
     "DP_RTR": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "DP_RTR",
@@ -4162,7 +4162,7 @@
     "DSW1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT1"
             ],
             "id": "DSW1",
@@ -4175,7 +4175,7 @@
     "DSW1_VAL": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT1"
             ],
             "id": "DSW1_VAL",
@@ -4188,7 +4188,7 @@
     "DSW2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT1"
             ],
             "id": "DSW2",
@@ -4201,7 +4201,7 @@
     "DSW2_VAL": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT1"
             ],
             "id": "DSW2_VAL",
@@ -4214,7 +4214,7 @@
     "DTCID": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSSTAT"
             ],
             "id": "DTCID",
@@ -4227,7 +4227,7 @@
     "DTOT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "DTOT",
@@ -4238,7 +4238,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "DTOT",
@@ -4251,7 +4251,7 @@
     "DTOT_ADJUST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "DTOT_ADJUST",
@@ -4264,7 +4264,7 @@
     "DTOT_ADJUST_TXT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "DTOT_ADJUST_TXT",
@@ -4277,7 +4277,7 @@
     "DTS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "DTS",
@@ -4288,7 +4288,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "DTS",
@@ -4299,7 +4299,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS2"
             ],
             "id": "DTS",
@@ -4310,7 +4310,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DTSDNLD",
                 "DTSSTAT",
                 "DTSUPLD"
@@ -4325,7 +4325,7 @@
     "DTSAS": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "DTSAS",
@@ -4338,7 +4338,7 @@
     "DTSAS_EGI_STATUS": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "1ST_LINE"
             ],
             "id": "DTSAS_EGI_STATUS",
@@ -4351,7 +4351,7 @@
     "DTSAS_HPU1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "DTSAS_HPU1",
@@ -4364,7 +4364,7 @@
     "DTSAS_ON_OFF": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "DTSAS_ON_OFF",
@@ -4377,7 +4377,7 @@
     "DTSAS_ON_OFF1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "DTSAS_ON_OFF1",
@@ -4390,7 +4390,7 @@
     "DTSAS_OWC": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "DTSAS_OWC",
@@ -4403,7 +4403,7 @@
     "DTSAS_OWC1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "DTSAS_OWC1",
@@ -4416,7 +4416,7 @@
     "DTSAS_ST0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "DTSAS_ST0",
@@ -4427,7 +4427,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "DTSAS_ST0",
@@ -4440,7 +4440,7 @@
     "DTSAS_ST2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "DTSAS_ST2",
@@ -4451,7 +4451,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "DTSAS_ST2",
@@ -4464,7 +4464,7 @@
     "DTSAS_ST3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "DTSAS_ST3",
@@ -4475,7 +4475,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "DTSAS_ST3",
@@ -4488,7 +4488,7 @@
     "DTSAS_SYMB": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "DTSAS_SYMB",
@@ -4501,7 +4501,7 @@
     "DTSAS_TXT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "DTSAS_TXT",
@@ -4514,7 +4514,7 @@
     "DTSAS_VPU1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "DTSAS_VPU1",
@@ -4527,7 +4527,7 @@
     "DTSDNLD": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "DTSDNLD",
@@ -4540,7 +4540,7 @@
     "DTSSTAT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "DTSSTAT",
@@ -4553,7 +4553,7 @@
     "DTSUPLD": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "DTSUPLD",
@@ -4566,7 +4566,7 @@
     "DTSUPLOAD": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "NAV"
             ],
             "id": "DTSUPLOAD",
@@ -4579,7 +4579,7 @@
     "DTS_LB": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "DTS_LB",
@@ -4592,7 +4592,7 @@
     "DTS_SA": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "DTS_SA",
@@ -4605,7 +4605,7 @@
     "DTS_ST0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "DTS_ST0",
@@ -4616,7 +4616,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "DTS_ST0",
@@ -4627,7 +4627,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "DTS_ST0",
@@ -4638,7 +4638,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "DTS_ST0",
@@ -4649,7 +4649,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSSTAT"
             ],
             "id": "DTS_ST0",
@@ -4662,7 +4662,7 @@
     "DTS_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "DTS_ST1",
@@ -4673,7 +4673,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "DTS_ST1",
@@ -4684,7 +4684,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "DTS_ST1",
@@ -4695,7 +4695,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "DTS_ST1",
@@ -4706,7 +4706,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSSTAT"
             ],
             "id": "DTS_ST1",
@@ -4719,7 +4719,7 @@
     "DTS_ST2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "DTS_ST2",
@@ -4730,7 +4730,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "DTS_ST2",
@@ -4741,7 +4741,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "DTS_ST2",
@@ -4752,7 +4752,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "DTS_ST2",
@@ -4763,7 +4763,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSSTAT"
             ],
             "id": "DTS_ST2",
@@ -4776,7 +4776,7 @@
     "DTS_ST3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "DTS_ST3",
@@ -4787,7 +4787,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "DTS_ST3",
@@ -4798,7 +4798,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "DTS_ST3",
@@ -4809,7 +4809,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "DTS_ST3",
@@ -4820,7 +4820,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSSTAT"
             ],
             "id": "DTS_ST3",
@@ -4833,7 +4833,7 @@
     "DTS_ST4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "DTS_ST4",
@@ -4844,7 +4844,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "DTS_ST4",
@@ -4855,7 +4855,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSSTAT"
             ],
             "id": "DTS_ST4",
@@ -4868,7 +4868,7 @@
     "DTS_STATUS0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "DTS_STATUS0",
@@ -4881,7 +4881,7 @@
     "DTS_STATUS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "DTS_STATUS1",
@@ -4894,7 +4894,7 @@
     "DTS_STATUS2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "DTS_STATUS2",
@@ -4907,7 +4907,7 @@
     "DTS_STATUS3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "DTS_STATUS3",
@@ -4920,7 +4920,7 @@
     "DTTG": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "DTTG",
@@ -4933,7 +4933,7 @@
     "DUR": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSKEYS"
             ],
             "id": "DUR",
@@ -4946,7 +4946,7 @@
     "DUR_VALS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSKEYS"
             ],
             "id": "DUR_VALS",
@@ -4959,7 +4959,7 @@
     "EEPROM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "EEPROM",
@@ -4970,7 +4970,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "EEPROM",
@@ -4983,7 +4983,7 @@
     "EGI": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGI",
@@ -4996,7 +4996,7 @@
     "EGIAvailableMode": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -5010,7 +5010,7 @@
     "EGIAvailableMode1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN"
             ],
             "id": "EGIAvailableMode1",
@@ -5021,7 +5021,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALTALGN"
             ],
             "id": "EGIAvailableMode1",
@@ -5034,7 +5034,7 @@
     "EGIAvailableMode2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN"
             ],
             "id": "EGIAvailableMode2",
@@ -5047,7 +5047,7 @@
     "EGICurrentMode": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGICurrentMode",
@@ -5058,7 +5058,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN"
             ],
             "id": "EGICurrentMode",
@@ -5069,7 +5069,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALTALGN"
             ],
             "id": "EGICurrentMode",
@@ -5082,7 +5082,7 @@
     "EGICurrentMode1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGICurrentMode1",
@@ -5093,7 +5093,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN"
             ],
             "id": "EGICurrentMode1",
@@ -5104,7 +5104,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALTALGN"
             ],
             "id": "EGICurrentMode1",
@@ -5117,7 +5117,7 @@
     "EGICurrentMode2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN"
             ],
             "id": "EGICurrentMode2",
@@ -5130,7 +5130,7 @@
     "EGIStatus": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus",
@@ -5141,7 +5141,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "EGIStatus",
@@ -5152,7 +5152,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "EGIStatus",
@@ -5163,7 +5163,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "EGIStatus",
@@ -5174,7 +5174,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGIStatus",
@@ -5187,7 +5187,7 @@
     "EGIStatus1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus1",
@@ -5198,7 +5198,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "EGIStatus1",
@@ -5209,7 +5209,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "EGIStatus1",
@@ -5220,7 +5220,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "EGIStatus1",
@@ -5231,7 +5231,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGIStatus1",
@@ -5244,7 +5244,7 @@
     "EGIStatus10": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus10",
@@ -5255,7 +5255,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "EGIStatus10",
@@ -5266,7 +5266,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGIStatus10",
@@ -5279,7 +5279,7 @@
     "EGIStatus11": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus11",
@@ -5290,7 +5290,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "EGIStatus11",
@@ -5301,7 +5301,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGIStatus11",
@@ -5314,7 +5314,7 @@
     "EGIStatus12": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus12",
@@ -5325,7 +5325,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "EGIStatus12",
@@ -5336,7 +5336,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGIStatus12",
@@ -5349,7 +5349,7 @@
     "EGIStatus13": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus13",
@@ -5360,7 +5360,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "EGIStatus13",
@@ -5371,7 +5371,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGIStatus13",
@@ -5384,7 +5384,7 @@
     "EGIStatus14": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus14",
@@ -5395,7 +5395,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "EGIStatus14",
@@ -5406,7 +5406,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGIStatus14",
@@ -5419,7 +5419,7 @@
     "EGIStatus15": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus15",
@@ -5432,7 +5432,7 @@
     "EGIStatus16": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus16",
@@ -5445,7 +5445,7 @@
     "EGIStatus2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus2",
@@ -5456,7 +5456,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "EGIStatus2",
@@ -5467,7 +5467,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "EGIStatus2",
@@ -5478,7 +5478,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "EGIStatus2",
@@ -5489,7 +5489,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGIStatus2",
@@ -5502,7 +5502,7 @@
     "EGIStatus3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus3",
@@ -5513,7 +5513,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "EGIStatus3",
@@ -5524,7 +5524,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "EGIStatus3",
@@ -5535,7 +5535,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "EGIStatus3",
@@ -5546,7 +5546,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGIStatus3",
@@ -5559,7 +5559,7 @@
     "EGIStatus4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus4",
@@ -5570,7 +5570,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "EGIStatus4",
@@ -5581,7 +5581,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "EGIStatus4",
@@ -5592,7 +5592,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "EGIStatus4",
@@ -5603,7 +5603,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGIStatus4",
@@ -5616,7 +5616,7 @@
     "EGIStatus5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus5",
@@ -5627,7 +5627,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "EGIStatus5",
@@ -5638,7 +5638,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGIStatus5",
@@ -5651,7 +5651,7 @@
     "EGIStatus6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus6",
@@ -5662,7 +5662,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "EGIStatus6",
@@ -5673,7 +5673,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGIStatus6",
@@ -5686,7 +5686,7 @@
     "EGIStatus7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus7",
@@ -5697,7 +5697,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "EGIStatus7",
@@ -5708,7 +5708,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGIStatus7",
@@ -5721,7 +5721,7 @@
     "EGIStatus8": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus8",
@@ -5732,7 +5732,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "EGIStatus8",
@@ -5743,7 +5743,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGIStatus8",
@@ -5756,7 +5756,7 @@
     "EGIStatus9": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGIStatus9",
@@ -5767,7 +5767,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "EGIStatus9",
@@ -5778,7 +5778,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "EGIStatus9",
@@ -5791,7 +5791,7 @@
     "EGITEST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "EGITEST",
@@ -5804,7 +5804,7 @@
     "EGI_BLD_FOM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_BLD_FOM",
@@ -5817,7 +5817,7 @@
     "EGI_BLD_FOM1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_BLD_FOM1",
@@ -5830,7 +5830,7 @@
     "EGI_BLD_FOM2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_BLD_FOM2",
@@ -5843,7 +5843,7 @@
     "EGI_BLD_FOM3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_BLD_FOM3",
@@ -5856,7 +5856,7 @@
     "EGI_BLD_FOM4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_BLD_FOM4",
@@ -5869,7 +5869,7 @@
     "EGI_BLD_FOM5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_BLD_FOM5",
@@ -5882,7 +5882,7 @@
     "EGI_BLD_FOM6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_BLD_FOM6",
@@ -5895,7 +5895,7 @@
     "EGI_BLD_FOM7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_BLD_FOM7",
@@ -5908,7 +5908,7 @@
     "EGI_BLD_FOM8": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_BLD_FOM8",
@@ -5921,7 +5921,7 @@
     "EGI_BLD_FOM9": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_BLD_FOM9",
@@ -5934,7 +5934,7 @@
     "EGI_GPS_EHE": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_EHE",
@@ -5947,7 +5947,7 @@
     "EGI_GPS_EHE1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_EHE1",
@@ -5960,7 +5960,7 @@
     "EGI_GPS_EVE": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_EVE",
@@ -5973,7 +5973,7 @@
     "EGI_GPS_EVE1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_EVE1",
@@ -5986,7 +5986,7 @@
     "EGI_GPS_FOM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_GPS_FOM",
@@ -5997,7 +5997,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_FOM",
@@ -6010,7 +6010,7 @@
     "EGI_GPS_FOM1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_GPS_FOM1",
@@ -6021,7 +6021,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_FOM1",
@@ -6034,7 +6034,7 @@
     "EGI_GPS_FOM2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_GPS_FOM2",
@@ -6045,7 +6045,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_FOM2",
@@ -6058,7 +6058,7 @@
     "EGI_GPS_FOM3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_GPS_FOM3",
@@ -6069,7 +6069,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_FOM3",
@@ -6082,7 +6082,7 @@
     "EGI_GPS_FOM4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_GPS_FOM4",
@@ -6093,7 +6093,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_FOM4",
@@ -6106,7 +6106,7 @@
     "EGI_GPS_FOM5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_GPS_FOM5",
@@ -6117,7 +6117,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_FOM5",
@@ -6130,7 +6130,7 @@
     "EGI_GPS_FOM6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_GPS_FOM6",
@@ -6141,7 +6141,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_FOM6",
@@ -6154,7 +6154,7 @@
     "EGI_GPS_FOM7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_GPS_FOM7",
@@ -6165,7 +6165,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_FOM7",
@@ -6178,7 +6178,7 @@
     "EGI_GPS_FOM8": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_GPS_FOM8",
@@ -6189,7 +6189,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_FOM8",
@@ -6202,7 +6202,7 @@
     "EGI_GPS_FOM9": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_GPS_FOM9",
@@ -6213,7 +6213,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_FOM9",
@@ -6226,7 +6226,7 @@
     "EGI_GPS_ST3": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_ST3",
@@ -6239,7 +6239,7 @@
     "EGI_GPS_ST31": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_ST31",
@@ -6252,7 +6252,7 @@
     "EGI_GPS_ST5": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_ST5",
@@ -6265,7 +6265,7 @@
     "EGI_GPS_ST51": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EGI_GPS_ST51",
@@ -6278,7 +6278,7 @@
     "EGI_INS_FOM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_INS_FOM",
@@ -6291,7 +6291,7 @@
     "EGI_INS_FOM1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_INS_FOM1",
@@ -6304,7 +6304,7 @@
     "EGI_INS_FOM2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_INS_FOM2",
@@ -6317,7 +6317,7 @@
     "EGI_INS_FOM3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_INS_FOM3",
@@ -6330,7 +6330,7 @@
     "EGI_INS_FOM4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_INS_FOM4",
@@ -6343,7 +6343,7 @@
     "EGI_INS_FOM5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_INS_FOM5",
@@ -6356,7 +6356,7 @@
     "EGI_INS_FOM6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_INS_FOM6",
@@ -6369,7 +6369,7 @@
     "EGI_INS_FOM7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_INS_FOM7",
@@ -6382,7 +6382,7 @@
     "EGI_INS_FOM8": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_INS_FOM8",
@@ -6395,7 +6395,7 @@
     "EGI_INS_FOM9": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "EGI_INS_FOM9",
@@ -6408,7 +6408,7 @@
     "EGI_OFP": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "EGI_OFP",
@@ -6421,7 +6421,7 @@
     "EGI_SA": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "EGI_SA",
@@ -6434,7 +6434,7 @@
     "EHE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EHE",
@@ -6447,7 +6447,7 @@
     "EL": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "EL",
@@ -6460,7 +6460,7 @@
     "ELEVATION": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "ELEVATION",
@@ -6473,7 +6473,7 @@
     "EMPTY": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "MXLOG"
             ],
             "id": "EMPTY",
@@ -6486,7 +6486,7 @@
     "ERASE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "MXLOG"
             ],
             "id": "ERASE",
@@ -6499,7 +6499,7 @@
     "ERASEFL": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "ERASEFL",
@@ -6512,7 +6512,7 @@
     "ERASEFs": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "ERASEFs",
@@ -6525,7 +6525,7 @@
     "ERASEFs1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "ERASEFs1",
@@ -6538,7 +6538,7 @@
     "ERASE_SA": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "MXLOG"
             ],
             "id": "ERASE_SA",
@@ -6551,7 +6551,7 @@
     "EVE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "EVE",
@@ -6564,7 +6564,7 @@
     "EX": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "BITBALL"
             ],
             "id": "EX",
@@ -6577,7 +6577,7 @@
     "EstimatedDrift": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -6591,7 +6591,7 @@
     "F": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "F",
@@ -6602,7 +6602,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "F",
@@ -6615,7 +6615,7 @@
     "FAST": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ALTALGN"
             ],
             "id": "FAST",
@@ -6628,7 +6628,7 @@
     "FAULT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "FAULT",
@@ -6641,7 +6641,7 @@
     "FAUL_STATUS0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "FAUL_STATUS0",
@@ -6654,7 +6654,7 @@
     "FAUL_STATUS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "FAUL_STATUS1",
@@ -6667,7 +6667,7 @@
     "FLDINFO": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "FLDINFO",
@@ -6680,7 +6680,7 @@
     "FLDINFO_APP_UHF": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "FLDINFO_APP_UHF",
@@ -6693,7 +6693,7 @@
     "FLDINFO_APP_VHF": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "FLDINFO_APP_VHF",
@@ -6706,7 +6706,7 @@
     "FLDINFO_BR": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "FLDINFO_BR",
@@ -6719,7 +6719,7 @@
     "FLDINFO_ELEV": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "FLDINFO_ELEV",
@@ -6732,7 +6732,7 @@
     "FLDINFO_ID": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "FLDINFO_ID",
@@ -6745,7 +6745,7 @@
     "FLDINFO_ILS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "FLDINFO_ILS1",
@@ -6758,7 +6758,7 @@
     "FLDINFO_ILS2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "FLDINFO_ILS2",
@@ -6771,7 +6771,7 @@
     "FLDINFO_NUM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "FLDINFO_NUM",
@@ -6784,7 +6784,7 @@
     "FLDINFO_Name": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "FLDINFO_Name",
@@ -6797,7 +6797,7 @@
     "FLDINFO_RWY_HD": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "FLDINFO_RWY_HD",
@@ -6810,7 +6810,7 @@
     "FLDINFO_RWY_HD2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "FLDINFO_RWY_HD2",
@@ -6823,7 +6823,7 @@
     "FLDINFO_RWY_LNG": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "FLDINFO_RWY_LNG",
@@ -6836,7 +6836,7 @@
     "FLDINFO_TAC_CHAN": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "FLDINFO_TAC_CHAN",
@@ -6849,7 +6849,7 @@
     "FLDINFO_TAC_OFF": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "FLDINFO_TAC_OFF",
@@ -6862,7 +6862,7 @@
     "FLDINFO_TWR_UHF": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "FLDINFO_TWR_UHF",
@@ -6875,7 +6875,7 @@
     "FLDINFO_TWR_VHF": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "FLDINFO_TWR_VHF",
@@ -6888,7 +6888,7 @@
     "FLIGHT DRIVER": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "FLIGHT DRIVER",
@@ -6901,7 +6901,7 @@
     "FLIGHT_DRIVER": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "NAV",
                 "POS"
             ],
@@ -6915,7 +6915,7 @@
     "FLIGHT_DRIVER1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "NAV",
                 "POS"
             ],
@@ -6927,7 +6927,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "FLIGHT_DRIVER1",
@@ -6940,7 +6940,7 @@
     "FLIGHT_DRIVER2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "NAV",
                 "POS"
             ],
@@ -6952,7 +6952,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "FLIGHT_DRIVER2",
@@ -6965,7 +6965,7 @@
     "FLIGHT_DRIVER3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "FLIGHT_DRIVER3",
@@ -6976,7 +6976,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POS"
             ],
             "id": "FLIGHT_DRIVER3",
@@ -6989,7 +6989,7 @@
     "FLIGHT_DRIVER4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "FLIGHT_DRIVER4",
@@ -7002,7 +7002,7 @@
     "FLTR_INS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "FLTR_INS",
@@ -7015,7 +7015,7 @@
     "FLTR_INSs": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "FLTR_INSs",
@@ -7028,7 +7028,7 @@
     "FLTR_INSs1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "FLTR_INSs1",
@@ -7041,7 +7041,7 @@
     "FOM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "FOM",
@@ -7052,7 +7052,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "FOM",
@@ -7065,7 +7065,7 @@
     "FOM_LINE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "FOM_LINE",
@@ -7078,7 +7078,7 @@
     "FPAction": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPAction",
@@ -7091,7 +7091,7 @@
     "FPAction1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPAction1",
@@ -7104,7 +7104,7 @@
     "FPAction2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPAction2",
@@ -7117,7 +7117,7 @@
     "FPBUILDBranch": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPBUILDBranch",
@@ -7130,7 +7130,7 @@
     "FPBUILDBranch1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPBUILDBranch1",
@@ -7143,7 +7143,7 @@
     "FPBUILDBranch2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPBUILDBranch2",
@@ -7156,7 +7156,7 @@
     "FPBUILDPlanName": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "FPBUILDPlanName",
@@ -7169,7 +7169,7 @@
     "FPBUILDPlanNumber": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "FPBUILDPlanNumber",
@@ -7182,7 +7182,7 @@
     "FPMode": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPMode",
@@ -7195,7 +7195,7 @@
     "FPMode1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPMode1",
@@ -7208,7 +7208,7 @@
     "FPMode2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPMode2",
@@ -7221,7 +7221,7 @@
     "FPMode3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPMode3",
@@ -7234,7 +7234,7 @@
     "FPMode4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPMode4",
@@ -7247,7 +7247,7 @@
     "FPMode5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPMode5",
@@ -7260,7 +7260,7 @@
     "FPName": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPName",
@@ -7273,7 +7273,7 @@
     "FPName1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPName1",
@@ -7286,7 +7286,7 @@
     "FPName2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPName2",
@@ -7299,7 +7299,7 @@
     "FPNameInput": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPNameInput",
@@ -7312,7 +7312,7 @@
     "FPNumber": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPNumber",
@@ -7325,7 +7325,7 @@
     "FPNumber1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPNumber1",
@@ -7338,7 +7338,7 @@
     "FPNumber2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FPNumber2",
@@ -7351,7 +7351,7 @@
     "FPP": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "FPP",
@@ -7362,7 +7362,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "FPP",
@@ -7375,7 +7375,7 @@
     "FROM_CF_RTRY": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_CF_RTRY",
@@ -7388,7 +7388,7 @@
     "FROM_CoordFormat0": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_CoordFormat0",
@@ -7401,7 +7401,7 @@
     "FROM_CoordFormat1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_CoordFormat1",
@@ -7414,7 +7414,7 @@
     "FROM_DataEntry0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_DataEntry0",
@@ -7427,7 +7427,7 @@
     "FROM_DataEntry1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_DataEntry1",
@@ -7440,7 +7440,7 @@
     "FROM_Lat": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_Lat",
@@ -7453,7 +7453,7 @@
     "FROM_Lat1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_Lat1",
@@ -7466,7 +7466,7 @@
     "FROM_Long": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_Long",
@@ -7479,7 +7479,7 @@
     "FROM_Long1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_Long1",
@@ -7492,7 +7492,7 @@
     "FROM_NUMBER": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "FROM_NUMBER",
@@ -7505,7 +7505,7 @@
     "FROM_PT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPMENU"
             ],
             "id": "FROM_PT",
@@ -7518,7 +7518,7 @@
     "FROM_PointArea": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_PointArea",
@@ -7531,7 +7531,7 @@
     "FROM_PointArea1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_PointArea1",
@@ -7544,7 +7544,7 @@
     "FROM_PointGrid": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_PointGrid",
@@ -7557,7 +7557,7 @@
     "FROM_PointGrid1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_PointGrid1",
@@ -7570,7 +7570,7 @@
     "FROM_TITLE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "FROM_TITLE",
@@ -7583,7 +7583,7 @@
     "FROM_WptIdent": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_WptIdent",
@@ -7596,7 +7596,7 @@
     "FROM_WptIdent1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_WptIdent1",
@@ -7609,7 +7609,7 @@
     "FROM_WptNumber": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_WptNumber",
@@ -7622,7 +7622,7 @@
     "FROM_WptNumber1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "FROM_WptNumber1",
@@ -7635,7 +7635,7 @@
     "FT_BRACKETS": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "FT_BRACKETS",
@@ -7648,7 +7648,7 @@
     "FT_TXT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "FT_TXT",
@@ -7661,7 +7661,7 @@
     "FULLText": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "FULLText",
@@ -7674,7 +7674,7 @@
     "FWI": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT2",
                 "GPSBIT3",
                 "GPSBIT4"
@@ -7689,7 +7689,7 @@
     "GC": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT1"
             ],
             "id": "GC",
@@ -7702,7 +7702,7 @@
     "GC1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT1"
             ],
             "id": "GC1",
@@ -7715,7 +7715,7 @@
     "GCAS_LAST_SOURCE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "GCAS_LAST_SOURCE",
@@ -7728,7 +7728,7 @@
     "GCAS_MSGS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "GCAS_MSGS",
@@ -7741,7 +7741,7 @@
     "GCAS_MSGS1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "GCAS_MSGS1",
@@ -7754,7 +7754,7 @@
     "GEM_OFP": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "GEM_OFP",
@@ -7767,7 +7767,7 @@
     "GEM_SA": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "GEM_SA",
@@ -7780,7 +7780,7 @@
     "GMT_DE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "GMT_DE",
@@ -7793,7 +7793,7 @@
     "GMT_LCL1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "GMT_LCL1",
@@ -7806,7 +7806,7 @@
     "GMT_LCL2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "GMT_LCL2",
@@ -7819,7 +7819,7 @@
     "GMT_LCL_Time": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "GMT_LCL_Time",
@@ -7832,7 +7832,7 @@
     "GPS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "GPS",
@@ -7843,7 +7843,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "GPS",
@@ -7854,7 +7854,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT1",
                 "GPSBIT2",
                 "GPSBIT3",
@@ -7869,7 +7869,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT4",
                 "GPSBIT5"
             ],
@@ -7881,7 +7881,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "GPS",
@@ -7894,7 +7894,7 @@
     "GPS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSDNLD"
             ],
             "id": "GPS1",
@@ -7905,7 +7905,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT4",
                 "GPSBIT5",
                 "GPSSTAT1"
@@ -7920,7 +7920,7 @@
     "GPS2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSDNLD"
             ],
             "id": "GPS2",
@@ -7933,7 +7933,7 @@
     "GPSAltitude": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO",
                 "POS"
             ],
@@ -7947,7 +7947,7 @@
     "GPSAltitude1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO",
                 "POS"
             ],
@@ -7961,7 +7961,7 @@
     "GPSAltitude2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "GPSAltitude2",
@@ -7974,7 +7974,7 @@
     "GPSAltitude3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "GPSAltitude3",
@@ -7987,7 +7987,7 @@
     "GPSAltitude4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "GPSAltitude4",
@@ -8000,7 +8000,7 @@
     "GPSBIT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "GPSBIT",
@@ -8013,7 +8013,7 @@
     "GPSKEYS": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "GPSKEYS",
@@ -8026,7 +8026,7 @@
     "GPSSTAT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "GPSSTAT",
@@ -8039,7 +8039,7 @@
     "GPSStatus": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "GPSStatus",
@@ -8050,7 +8050,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "GPSStatus",
@@ -8063,7 +8063,7 @@
     "GPSStatus1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "GPSStatus1",
@@ -8074,7 +8074,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "GPSStatus1",
@@ -8087,7 +8087,7 @@
     "GPSStatus2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "GPSStatus2",
@@ -8098,7 +8098,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "GPSStatus2",
@@ -8111,7 +8111,7 @@
     "GPSStatus3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "GPSStatus3",
@@ -8122,7 +8122,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "GPSStatus3",
@@ -8135,7 +8135,7 @@
     "GPSStatus4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "GPSStatus4",
@@ -8146,7 +8146,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "GPSStatus4",
@@ -8159,7 +8159,7 @@
     "GPS_SA": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "GPS_SA",
@@ -8172,7 +8172,7 @@
     "GPS_SA1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "GPS_SA1",
@@ -8185,7 +8185,7 @@
     "GPS_STATUS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "GPS_STATUS",
@@ -8198,7 +8198,7 @@
     "GPS_STATUS0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "GPS_STATUS0",
@@ -8211,7 +8211,7 @@
     "GPS_STATUS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "GPS_STATUS1",
@@ -8224,7 +8224,7 @@
     "GPS_STATUS2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "GPS_STATUS2",
@@ -8237,7 +8237,7 @@
     "GPS_STATUS3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "GPS_STATUS3",
@@ -8250,7 +8250,7 @@
     "GROUND": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN"
             ],
             "id": "GROUND",
@@ -8263,7 +8263,7 @@
     "GUK_USER": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "GUK_USER",
@@ -8276,7 +8276,7 @@
     "GUK_USERs": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "GUK_USERs",
@@ -8289,7 +8289,7 @@
     "GUK_USERs1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "GUK_USERs1",
@@ -8302,7 +8302,7 @@
     "G_ALT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO",
                 "POS"
             ],
@@ -8316,7 +8316,7 @@
     "HARS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "HARS",
@@ -8327,7 +8327,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "HARS",
@@ -8338,7 +8338,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "HARS",
@@ -8351,7 +8351,7 @@
     "HARS_I_F": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "HARS_I_F",
@@ -8362,7 +8362,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "HARS_I_F",
@@ -8375,7 +8375,7 @@
     "HARS_ST2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "HARS_ST2",
@@ -8386,7 +8386,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "HARS_ST2",
@@ -8397,7 +8397,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "HARS_ST2",
@@ -8408,7 +8408,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "HARS_ST2",
@@ -8421,7 +8421,7 @@
     "HARS_ST3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "HARS_ST3",
@@ -8432,7 +8432,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "HARS_ST3",
@@ -8443,7 +8443,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "HARS_ST3",
@@ -8454,7 +8454,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "HARS_ST3",
@@ -8467,7 +8467,7 @@
     "HAS_KEYS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "HAS_KEYS",
@@ -8480,7 +8480,7 @@
     "HAS_KEYSs": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "HAS_KEYSs",
@@ -8493,7 +8493,7 @@
     "HAS_KEYSs1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "HAS_KEYSs1",
@@ -8506,7 +8506,7 @@
     "HPU": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "HPU",
@@ -8519,7 +8519,7 @@
     "HUD_ATT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "HUD_ATT",
@@ -8532,7 +8532,7 @@
     "HUD_ATT1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "HUD_ATT1",
@@ -8545,7 +8545,7 @@
     "HUD_ATT2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "HUD_ATT2",
@@ -8558,7 +8558,7 @@
     "HUD_IND": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "HUD_IND",
@@ -8571,7 +8571,7 @@
     "HUD_OFF": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "HUD_OFF",
@@ -8584,7 +8584,7 @@
     "HUD_ON": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "HUD_ON",
@@ -8597,7 +8597,7 @@
     "IAS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "IAS",
@@ -8610,7 +8610,7 @@
     "IAS_ST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "IAS_ST",
@@ -8623,7 +8623,7 @@
     "IAS_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "IAS_ST1",
@@ -8636,7 +8636,7 @@
     "IAS_VAL": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "IAS_VAL",
@@ -8649,7 +8649,7 @@
     "IE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "IE",
@@ -8662,7 +8662,7 @@
     "IE_STATUS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "IE_STATUS",
@@ -8675,7 +8675,7 @@
     "IIW": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT5"
             ],
             "id": "IIW",
@@ -8688,7 +8688,7 @@
     "ILS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "ILS",
@@ -8701,7 +8701,7 @@
     "ILS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "ILS1",
@@ -8714,7 +8714,7 @@
     "INCR": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "MXLOG"
             ],
             "id": "INCR",
@@ -8727,7 +8727,7 @@
     "INFLT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN"
             ],
             "id": "INFLT",
@@ -8740,7 +8740,7 @@
     "INIT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "INIT",
@@ -8751,7 +8751,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "INIT",
@@ -8764,7 +8764,7 @@
     "INITWAYPTIdent1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "INITWAYPTIdent1",
@@ -8777,7 +8777,7 @@
     "INITWAYPTIdent2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "INITWAYPTIdent2",
@@ -8790,7 +8790,7 @@
     "INITWAYPTNumber1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "INITWAYPTNumber1",
@@ -8803,7 +8803,7 @@
     "INITWAYPTNumber2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "INITWAYPTNumber2",
@@ -8816,7 +8816,7 @@
     "INITWAYPT_INCR_DECR": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "INITWAYPT_INCR_DECR",
@@ -8829,7 +8829,7 @@
     "INIT_REQ": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "INIT_REQ",
@@ -8842,7 +8842,7 @@
     "INIT_REQs": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "INIT_REQs",
@@ -8855,7 +8855,7 @@
     "INIT_REQs1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "INIT_REQs1",
@@ -8868,7 +8868,7 @@
     "INS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "INS",
@@ -8879,7 +8879,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -8891,7 +8891,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "INS",
@@ -8902,7 +8902,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "INS",
@@ -8913,7 +8913,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "INS",
@@ -8926,7 +8926,7 @@
     "INS1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "INS1",
@@ -8939,7 +8939,7 @@
     "INS2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "INS2",
@@ -8952,7 +8952,7 @@
     "INSERT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "INSERT",
@@ -8965,7 +8965,7 @@
     "INSERTDisplay": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "INSERTDisplay",
@@ -8978,7 +8978,7 @@
     "INSSTAT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "INS"
             ],
             "id": "INSSTAT",
@@ -8991,7 +8991,7 @@
     "INS_SA": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "INS_SA",
@@ -9004,7 +9004,7 @@
     "INS_ST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "INS_ST",
@@ -9017,7 +9017,7 @@
     "INS_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "INS_ST1",
@@ -9030,7 +9030,7 @@
     "INS_ST2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "INS_ST2",
@@ -9043,7 +9043,7 @@
     "INS_ST3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "INS_ST3",
@@ -9056,7 +9056,7 @@
     "INS_ST4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "INS_ST4",
@@ -9069,7 +9069,7 @@
     "INS_ST5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "INS_ST5",
@@ -9082,7 +9082,7 @@
     "INS_STATUS0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "INS_STATUS0",
@@ -9095,7 +9095,7 @@
     "INS_STATUS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "INS_STATUS1",
@@ -9108,7 +9108,7 @@
     "INS_STATUS2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "INS_STATUS2",
@@ -9121,7 +9121,7 @@
     "INS_STATUS3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "INS_STATUS3",
@@ -9134,7 +9134,7 @@
     "INVALID": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "INVALID",
@@ -9147,7 +9147,7 @@
     "INVALID_ST0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "INVALID_ST0",
@@ -9160,7 +9160,7 @@
     "INVALID_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "INVALID_ST1",
@@ -9173,7 +9173,7 @@
     "IN_FP": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "IN_FP",
@@ -9186,7 +9186,7 @@
     "ISA": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "ISA",
@@ -9199,7 +9199,7 @@
     "ISA_STATUS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "ISA_STATUS",
@@ -9212,7 +9212,7 @@
     "I_F_1553": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "I_F_1553",
@@ -9225,7 +9225,7 @@
     "InitInputLatUTM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -9239,7 +9239,7 @@
     "InitInputLongMGRS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -9253,7 +9253,7 @@
     "InitPosCoordFormat_LL": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -9267,7 +9267,7 @@
     "InitPosCoordFormat_UTM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -9281,7 +9281,7 @@
     "InitPositLat": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -9295,7 +9295,7 @@
     "InitPositLong": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -9309,7 +9309,7 @@
     "InitPositMGRS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -9323,7 +9323,7 @@
     "InitPositText": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -9337,7 +9337,7 @@
     "InitPositUTM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -9351,7 +9351,7 @@
     "KEYLOAD": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "KEYLOAD",
@@ -9364,7 +9364,7 @@
     "KEY_2HR": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "KEY_2HR",
@@ -9377,7 +9377,7 @@
     "KEY_DUR": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPSKEYS"
             ],
             "id": "KEY_DUR",
@@ -9388,7 +9388,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "KEY_DUR",
@@ -9401,7 +9401,7 @@
     "KEY_PAR": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "KEY_PAR",
@@ -9414,7 +9414,7 @@
     "KEY_PARs": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "KEY_PARs",
@@ -9427,7 +9427,7 @@
     "KEY_PARs1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "KEY_PARs1",
@@ -9440,7 +9440,7 @@
     "KEY_PARs2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "KEY_PARs2",
@@ -9453,7 +9453,7 @@
     "KEY_PARs3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "KEY_PARs3",
@@ -9466,7 +9466,7 @@
     "KEY_REM": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPSKEYS"
             ],
             "id": "KEY_REM",
@@ -9477,7 +9477,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "KEY_REM",
@@ -9490,7 +9490,7 @@
     "KEY_USED": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "KEY_USED",
@@ -9503,7 +9503,7 @@
     "KEY_USEDs": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "KEY_USEDs",
@@ -9516,7 +9516,7 @@
     "KEY_USEDs1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "KEY_USEDs1",
@@ -9529,7 +9529,7 @@
     "KEY_USEDs2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "KEY_USEDs2",
@@ -9542,7 +9542,7 @@
     "KEY_USEDs3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "KEY_USEDs3",
@@ -9555,7 +9555,7 @@
     "KLDs": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "KLDs",
@@ -9568,7 +9568,7 @@
     "KLDs1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "KLDs1",
@@ -9581,7 +9581,7 @@
     "KYK": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT1"
             ],
             "id": "KYK",
@@ -9594,7 +9594,7 @@
     "L4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT2",
                 "GPSBIT3"
             ],
@@ -9608,7 +9608,7 @@
     "L5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT2",
                 "GPSBIT3"
             ],
@@ -9622,7 +9622,7 @@
     "LAR": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "LAR",
@@ -9635,7 +9635,7 @@
     "LAR_VALUE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "LAR_VALUE",
@@ -9648,7 +9648,7 @@
     "LAR_VALUE1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "LAR_VALUE1",
@@ -9661,7 +9661,7 @@
     "LAR_VALUE2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "LAR_VALUE2",
@@ -9674,7 +9674,7 @@
     "LASTE": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "LASTE",
@@ -9685,7 +9685,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "LASTE",
@@ -9698,7 +9698,7 @@
     "LASTE_ST0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "LASTE_ST0",
@@ -9709,7 +9709,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "LASTE_ST0",
@@ -9720,7 +9720,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "LASTE_ST0",
@@ -9733,7 +9733,7 @@
     "LASTE_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "LASTE_ST1",
@@ -9746,7 +9746,7 @@
     "LASTE_ST2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "LASTE_ST2",
@@ -9757,7 +9757,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "LASTE_ST2",
@@ -9770,7 +9770,7 @@
     "LASTE_V": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "LASTE_V",
@@ -9783,7 +9783,7 @@
     "LCL_ADJUST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "LCL_ADJUST",
@@ -9796,7 +9796,7 @@
     "LCL_ADJUST_TXT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "LCL_ADJUST_TXT",
@@ -9809,7 +9809,7 @@
     "LINE7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSSTAT"
             ],
             "id": "LINE7",
@@ -9822,7 +9822,7 @@
     "LINE9": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSSTAT"
             ],
             "id": "LINE9",
@@ -9835,7 +9835,7 @@
     "LOAD_PASS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "LOAD_PASS",
@@ -9848,7 +9848,7 @@
     "LRU1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSDNLD"
             ],
             "id": "LRU1",
@@ -9861,7 +9861,7 @@
     "LRU2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSDNLD"
             ],
             "id": "LRU2",
@@ -9874,7 +9874,7 @@
     "LRUTEST": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1",
                 "EGITEST"
             ],
@@ -9886,7 +9886,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS2"
             ],
             "id": "LRUTEST",
@@ -9899,7 +9899,7 @@
     "LRU_CADC": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "LRU_CADC",
@@ -9912,7 +9912,7 @@
     "LRU_CDU": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "LRU_CDU",
@@ -9925,7 +9925,7 @@
     "LRU_DTS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "LRU_DTS",
@@ -9938,7 +9938,7 @@
     "LRU_DTSAS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "LRU_DTSAS",
@@ -9951,7 +9951,7 @@
     "LRU_GPS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "LRU_GPS",
@@ -9964,7 +9964,7 @@
     "LRU_HARS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "LRU_HARS",
@@ -9977,7 +9977,7 @@
     "LRU_INS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "LRU_INS",
@@ -9990,7 +9990,7 @@
     "LRU_LASTE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "LRU_LASTE",
@@ -10003,7 +10003,7 @@
     "LRU_MBC": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "LRU_MBC",
@@ -10016,7 +10016,7 @@
     "LRU_MSN": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "LRU_MSN",
@@ -10029,7 +10029,7 @@
     "MACH": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "MACH",
@@ -10040,7 +10040,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "MACH",
@@ -10053,7 +10053,7 @@
     "MACH_ST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "MACH_ST",
@@ -10066,7 +10066,7 @@
     "MACH_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "MACH_ST1",
@@ -10079,7 +10079,7 @@
     "MACH_VAL": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "MACH_VAL",
@@ -10092,7 +10092,7 @@
     "MAGH_ST2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "MAGH_ST2",
@@ -10105,7 +10105,7 @@
     "MAGH_ST3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "MAGH_ST3",
@@ -10118,7 +10118,7 @@
     "MAGH_VAL": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "MAGH_VAL",
@@ -10131,7 +10131,7 @@
     "MAG_HEAD": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "MAG_HEAD",
@@ -10144,7 +10144,7 @@
     "MBC": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "MBC",
@@ -10157,7 +10157,7 @@
     "MBC1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "MBC1",
@@ -10170,7 +10170,7 @@
     "MBIT1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI3"
             ],
             "id": "MBIT1",
@@ -10183,7 +10183,7 @@
     "MBIT10": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI3"
             ],
             "id": "MBIT10",
@@ -10196,7 +10196,7 @@
     "MBIT11": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI3"
             ],
             "id": "MBIT11",
@@ -10209,7 +10209,7 @@
     "MBIT2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI3"
             ],
             "id": "MBIT2",
@@ -10222,7 +10222,7 @@
     "MBIT3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI3"
             ],
             "id": "MBIT3",
@@ -10235,7 +10235,7 @@
     "MBIT4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI3"
             ],
             "id": "MBIT4",
@@ -10248,7 +10248,7 @@
     "MBIT5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI3"
             ],
             "id": "MBIT5",
@@ -10261,7 +10261,7 @@
     "MBIT6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI3"
             ],
             "id": "MBIT6",
@@ -10274,7 +10274,7 @@
     "MBIT7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI3"
             ],
             "id": "MBIT7",
@@ -10287,7 +10287,7 @@
     "MBIT8": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI3"
             ],
             "id": "MBIT8",
@@ -10300,7 +10300,7 @@
     "MBIT9": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI3"
             ],
             "id": "MBIT9",
@@ -10313,7 +10313,7 @@
     "MH": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ALTALGN"
             ],
             "id": "MH",
@@ -10326,7 +10326,7 @@
     "MH1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ALTALGN"
             ],
             "id": "MH1",
@@ -10339,7 +10339,7 @@
     "MHD": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ"
             ],
             "id": "MHD",
@@ -10352,7 +10352,7 @@
     "MHD_ERR": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ"
             ],
             "id": "MHD_ERR",
@@ -10365,7 +10365,7 @@
     "MH_DE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALTALGN"
             ],
             "id": "MH_DE",
@@ -10378,7 +10378,7 @@
     "MISC_ADDR": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INS"
             ],
             "id": "MISC_ADDR",
@@ -10391,7 +10391,7 @@
     "MISSION": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "MXLOG"
             ],
             "id": "MISSION",
@@ -10404,7 +10404,7 @@
     "MODE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSSTAT"
             ],
             "id": "MODE",
@@ -10415,7 +10415,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "MODE",
@@ -10428,7 +10428,7 @@
     "MODE0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "MODE0",
@@ -10441,7 +10441,7 @@
     "MODE1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "MODE1",
@@ -10454,7 +10454,7 @@
     "MODE2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "MODE2",
@@ -10467,7 +10467,7 @@
     "MODE3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "MODE3",
@@ -10480,7 +10480,7 @@
     "MODE4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "MODE4",
@@ -10493,7 +10493,7 @@
     "MODE5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "MODE5",
@@ -10506,7 +10506,7 @@
     "MODE6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "MODE6",
@@ -10519,7 +10519,7 @@
     "MODE7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "MODE7",
@@ -10532,7 +10532,7 @@
     "MODE8": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "MODE8",
@@ -10545,7 +10545,7 @@
     "MODE9": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "MODE9",
@@ -10558,7 +10558,7 @@
     "MONTH": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "MONTH",
@@ -10571,7 +10571,7 @@
     "MONTH_DE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "MONTH_DE",
@@ -10584,7 +10584,7 @@
     "MONTH_TXT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "MONTH_TXT",
@@ -10597,7 +10597,7 @@
     "MSN": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "MSN",
@@ -10608,7 +10608,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "MSN",
@@ -10619,7 +10619,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "MSN",
@@ -10632,7 +10632,7 @@
     "MSN_DUR": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "MSN_DUR",
@@ -10645,7 +10645,7 @@
     "MSN_SA": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "MSN_SA",
@@ -10658,7 +10658,7 @@
     "MSN_STATUS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "MSN_STATUS",
@@ -10671,7 +10671,7 @@
     "MSN_STATUS0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "MSN_STATUS0",
@@ -10684,7 +10684,7 @@
     "MSN_STATUS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "MSN_STATUS1",
@@ -10697,7 +10697,7 @@
     "MSN_STATUS2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "MSN_STATUS2",
@@ -10710,7 +10710,7 @@
     "MSN_STATUS3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "MSN_STATUS3",
@@ -10723,7 +10723,7 @@
     "MV": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "MV",
@@ -10734,7 +10734,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "MV",
@@ -10747,7 +10747,7 @@
     "MV1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "MV1",
@@ -10760,7 +10760,7 @@
     "MV2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "MV2",
@@ -10773,7 +10773,7 @@
     "MV3": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "MV3",
@@ -10786,7 +10786,7 @@
     "MV4": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "MV4",
@@ -10799,7 +10799,7 @@
     "MV5": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "MV5",
@@ -10812,7 +10812,7 @@
     "MV6": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "MV6",
@@ -10825,7 +10825,7 @@
     "MV_EQ": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "MV_EQ",
@@ -10838,7 +10838,7 @@
     "MV_EQ1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "MV_EQ1",
@@ -10851,7 +10851,7 @@
     "MV_EQ2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "MV_EQ2",
@@ -10864,7 +10864,7 @@
     "MXLOG": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "SYS2"
             ],
             "id": "MXLOG",
@@ -10877,7 +10877,7 @@
     "MXOPT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "MXLOG"
             ],
             "id": "MXOPT",
@@ -10890,7 +10890,7 @@
     "Mach": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "Mach",
@@ -10903,7 +10903,7 @@
     "NAV": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "NAV",
@@ -10914,7 +10914,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -10928,7 +10928,7 @@
     "NAVMODEROTARY": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "NAV",
                 "POS"
             ],
@@ -10942,7 +10942,7 @@
     "NAV_DAT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "NAV_DAT",
@@ -10955,7 +10955,7 @@
     "NAV_DAT1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "NAV_DAT1",
@@ -10968,7 +10968,7 @@
     "NAV_DAT2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "NAV_DAT2",
@@ -10981,7 +10981,7 @@
     "NAV_DATA": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "NAV_DATA",
@@ -10994,7 +10994,7 @@
     "NAV_DATAs": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "NAV_DATAs",
@@ -11007,7 +11007,7 @@
     "NAV_DATAs1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "NAV_DATAs1",
@@ -11020,7 +11020,7 @@
     "NAV_RDY": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "NAV_RDY",
@@ -11033,7 +11033,7 @@
     "NAV_RDY1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "NAV_RDY1",
@@ -11046,7 +11046,7 @@
     "NAV_RDY2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "NAV_RDY2",
@@ -11059,7 +11059,7 @@
     "NAV_RDY3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "NAV_RDY3",
@@ -11072,7 +11072,7 @@
     "NEWFPNumber": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "NEWFPNumber",
@@ -11085,7 +11085,7 @@
     "NEWFPText": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "NEWFPText",
@@ -11098,7 +11098,7 @@
     "NEW_WAYPT_NUM": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET",
                 "WAYPT1"
             ],
@@ -11112,7 +11112,7 @@
     "NM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "NM",
@@ -11125,7 +11125,7 @@
     "NMDisplay": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "NMDisplay",
@@ -11138,7 +11138,7 @@
     "NMINPUT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "NMINPUT",
@@ -11151,7 +11151,7 @@
     "NOT_ATTEMPTED": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "NOT_ATTEMPTED",
@@ -11164,7 +11164,7 @@
     "NS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ"
             ],
             "id": "NS",
@@ -11177,7 +11177,7 @@
     "NS_ERR": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ"
             ],
             "id": "NS_ERR",
@@ -11190,7 +11190,7 @@
     "NUM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANNUNCIATIONS"
             ],
             "id": "NUM",
@@ -11203,7 +11203,7 @@
     "OAT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "OAT",
@@ -11216,7 +11216,7 @@
     "OF": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "BITBALL"
             ],
             "id": "OF",
@@ -11229,7 +11229,7 @@
     "OFFSETDIV": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "OFFSETDIV",
@@ -11242,7 +11242,7 @@
     "OFFSETWAYPTCoordFormat1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "OFFSETWAYPTCoordFormat1",
@@ -11255,7 +11255,7 @@
     "OFFSETWAYPTCoordFormat2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "OFFSETWAYPTCoordFormat2",
@@ -11268,7 +11268,7 @@
     "OFFSETWAYPTDIS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "OFFSETWAYPTDIS1",
@@ -11281,7 +11281,7 @@
     "OFFSETWAYPTDIS2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "OFFSETWAYPTDIS2",
@@ -11294,7 +11294,7 @@
     "OFFSETWAYPTLat": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "OFFSETWAYPTLat",
@@ -11307,7 +11307,7 @@
     "OFFSETWAYPTLatUTM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "OFFSETWAYPTLatUTM",
@@ -11320,7 +11320,7 @@
     "OFFSETWAYPTLong": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "OFFSETWAYPTLong",
@@ -11333,7 +11333,7 @@
     "OFFSETWAYPTLongMGRS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "OFFSETWAYPTLongMGRS",
@@ -11346,7 +11346,7 @@
     "OFFSETWAYPTMGRS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "OFFSETWAYPTMGRS",
@@ -11359,7 +11359,7 @@
     "OFFSETWAYPTMH1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "OFFSETWAYPTMH1",
@@ -11372,7 +11372,7 @@
     "OFFSETWAYPTMH2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "OFFSETWAYPTMH2",
@@ -11385,7 +11385,7 @@
     "OFFSETWAYPTNumber1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "OFFSETWAYPTNumber1",
@@ -11398,7 +11398,7 @@
     "OFFSETWAYPTNumber2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "OFFSETWAYPTNumber2",
@@ -11411,7 +11411,7 @@
     "OFFSETWAYPTUTM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "OFFSETWAYPTUTM",
@@ -11424,7 +11424,7 @@
     "OFP": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "OFP",
@@ -11437,7 +11437,7 @@
     "OFPID": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS2"
             ],
             "id": "OFPID",
@@ -11450,7 +11450,7 @@
     "OFPID1_LINE3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID1"
             ],
             "id": "OFPID1_LINE3",
@@ -11463,7 +11463,7 @@
     "OFPID1_LINE4_1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID1"
             ],
             "id": "OFPID1_LINE4_1",
@@ -11476,7 +11476,7 @@
     "OFPID1_LINE4_2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID1"
             ],
             "id": "OFPID1_LINE4_2",
@@ -11489,7 +11489,7 @@
     "OFPID1_LINE5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID1"
             ],
             "id": "OFPID1_LINE5",
@@ -11502,7 +11502,7 @@
     "OFPID1_LINE6_1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID1"
             ],
             "id": "OFPID1_LINE6_1",
@@ -11515,7 +11515,7 @@
     "OFPID1_LINE6_2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID1"
             ],
             "id": "OFPID1_LINE6_2",
@@ -11528,7 +11528,7 @@
     "OFPID1_LINE7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID1"
             ],
             "id": "OFPID1_LINE7",
@@ -11541,7 +11541,7 @@
     "OFPID1_LINE8": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID1"
             ],
             "id": "OFPID1_LINE8",
@@ -11554,7 +11554,7 @@
     "OFPID2_LINE3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID2"
             ],
             "id": "OFPID2_LINE3",
@@ -11567,7 +11567,7 @@
     "OFPID2_LINE4_1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID2"
             ],
             "id": "OFPID2_LINE4_1",
@@ -11580,7 +11580,7 @@
     "OFPID2_LINE4_2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID2"
             ],
             "id": "OFPID2_LINE4_2",
@@ -11593,7 +11593,7 @@
     "OFPID2_LINE5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID2"
             ],
             "id": "OFPID2_LINE5",
@@ -11606,7 +11606,7 @@
     "OFPID2_LINE6_1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID2"
             ],
             "id": "OFPID2_LINE6_1",
@@ -11619,7 +11619,7 @@
     "OFPID2_LINE6_2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID2"
             ],
             "id": "OFPID2_LINE6_2",
@@ -11632,7 +11632,7 @@
     "OFPID2_LINE7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID2"
             ],
             "id": "OFPID2_LINE7",
@@ -11645,7 +11645,7 @@
     "OFPID2_LINE8": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID2"
             ],
             "id": "OFPID2_LINE8",
@@ -11658,7 +11658,7 @@
     "OFP_SA": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "OFP_SA",
@@ -11671,7 +11671,7 @@
     "OPTIOMS_MAGHEAD": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "OPTIONS"
             ],
             "id": "OPTIOMS_MAGHEAD",
@@ -11684,7 +11684,7 @@
     "OPTIONS": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "NAV"
             ],
             "id": "OPTIONS",
@@ -11697,7 +11697,7 @@
     "OPTIONS_CF": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OPTIONS"
             ],
             "id": "OPTIONS_CF",
@@ -11710,7 +11710,7 @@
     "OPTIONS_DE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OPTIONS"
             ],
             "id": "OPTIONS_DE",
@@ -11723,7 +11723,7 @@
     "OPTIONS_EQUAL": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OPTIONS"
             ],
             "id": "OPTIONS_EQUAL",
@@ -11734,7 +11734,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "OPTIONS_EQUAL",
@@ -11747,7 +11747,7 @@
     "OPTIONS_EQUAL1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OPTIONS"
             ],
             "id": "OPTIONS_EQUAL1",
@@ -11760,7 +11760,7 @@
     "OPTIONS_HD0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OPTIONS"
             ],
             "id": "OPTIONS_HD0",
@@ -11773,7 +11773,7 @@
     "OPTIONS_HD1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OPTIONS"
             ],
             "id": "OPTIONS_HD1",
@@ -11786,7 +11786,7 @@
     "OPTIONS_HF0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OPTIONS"
             ],
             "id": "OPTIONS_HF0",
@@ -11799,7 +11799,7 @@
     "OPTIONS_HF1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OPTIONS"
             ],
             "id": "OPTIONS_HF1",
@@ -11812,7 +11812,7 @@
     "OPTIONS_HS0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OPTIONS"
             ],
             "id": "OPTIONS_HS0",
@@ -11823,7 +11823,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "OPTIONS_HS0",
@@ -11836,7 +11836,7 @@
     "OPTIONS_HS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OPTIONS"
             ],
             "id": "OPTIONS_HS1",
@@ -11849,7 +11849,7 @@
     "OPTIONS_MV": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "OPTIONS"
             ],
             "id": "OPTIONS_MV",
@@ -11862,7 +11862,7 @@
     "OPTIONS_RTRY": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OPTIONS"
             ],
             "id": "OPTIONS_RTRY",
@@ -11875,7 +11875,7 @@
     "ORIG_NAV": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSUPLD"
             ],
             "id": "ORIG_NAV",
@@ -11888,7 +11888,7 @@
     "OWC": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "OWC",
@@ -11901,7 +11901,7 @@
     "OWC1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "OWC1",
@@ -11914,7 +11914,7 @@
     "OWC_VALUE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "OWC_VALUE",
@@ -11927,7 +11927,7 @@
     "OWC_VALUE1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "OWC_VALUE1",
@@ -11940,7 +11940,7 @@
     "OWC_VALUE2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "OWC_VALUE2",
@@ -11953,7 +11953,7 @@
     "Overload": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "Overload",
@@ -11966,7 +11966,7 @@
     "Overload1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "Overload1",
@@ -11979,7 +11979,7 @@
     "Overload2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "Overload2",
@@ -11992,7 +11992,7 @@
     "Overload3": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "Overload3",
@@ -12005,7 +12005,7 @@
     "Overload4": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "Overload4",
@@ -12018,7 +12018,7 @@
     "PC": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "BITBALL"
             ],
             "id": "PC",
@@ -12031,7 +12031,7 @@
     "PGCAS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "PGCAS",
@@ -12044,7 +12044,7 @@
     "PGCAS_VALUE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "PGCAS_VALUE",
@@ -12057,7 +12057,7 @@
     "PGCAS_VALUE1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "PGCAS_VALUE1",
@@ -12070,7 +12070,7 @@
     "PGCAS_VALUE2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "PGCAS_VALUE2",
@@ -12083,7 +12083,7 @@
     "PITCH": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "PITCH",
@@ -12096,7 +12096,7 @@
     "PITCH_ST2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "PITCH_ST2",
@@ -12109,7 +12109,7 @@
     "PITCH_ST3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "PITCH_ST3",
@@ -12122,7 +12122,7 @@
     "PITCH_VAL": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "PITCH_VAL",
@@ -12135,7 +12135,7 @@
     "POS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INS"
             ],
             "id": "POS",
@@ -12148,7 +12148,7 @@
     "POS_SOURCE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -12162,7 +12162,7 @@
     "POS_Source_DTS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -12176,7 +12176,7 @@
     "POS_Source_GPS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -12190,7 +12190,7 @@
     "POS_Source_GPS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -12204,7 +12204,7 @@
     "POS_Source_Last_Pos": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -12218,7 +12218,7 @@
     "POS_Source_Man": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -12232,7 +12232,7 @@
     "POS_Source_Standby": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -12246,7 +12246,7 @@
     "PPOSGroundSpeed": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "PPOSGroundSpeed",
@@ -12259,7 +12259,7 @@
     "PPOSGroundSpeed1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "PPOSGroundSpeed1",
@@ -12272,7 +12272,7 @@
     "PPOSGroundSpeed2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "PPOSGroundSpeed2",
@@ -12285,7 +12285,7 @@
     "PPOSIAS": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "PPOSIAS",
@@ -12298,7 +12298,7 @@
     "PPOSSpeedMode": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "PPOSSpeedMode",
@@ -12311,7 +12311,7 @@
     "PPOSSpeedMode1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "PPOSSpeedMode1",
@@ -12324,7 +12324,7 @@
     "PPOSSpeedMode2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "PPOSSpeedMode2",
@@ -12337,7 +12337,7 @@
     "PPOSSpeedMode3": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "PPOSSpeedMode3",
@@ -12350,7 +12350,7 @@
     "PPOSSpeedMode4": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "PPOSSpeedMode4",
@@ -12363,7 +12363,7 @@
     "PPOSSpeedMode5": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "PPOSSpeedMode5",
@@ -12376,7 +12376,7 @@
     "PPOSSpeedRotary": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "PPOSSpeedRotary",
@@ -12389,7 +12389,7 @@
     "PPOSTAS1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "PPOSTAS1",
@@ -12402,7 +12402,7 @@
     "PR": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "PR",
@@ -12415,7 +12415,7 @@
     "PREF": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "DTSUPLD"
             ],
             "id": "PREF",
@@ -12428,7 +12428,7 @@
     "PR_VALUE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "PR_VALUE",
@@ -12441,7 +12441,7 @@
     "PR_VALUE1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "PR_VALUE1",
@@ -12454,7 +12454,7 @@
     "PR_VALUE2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "PR_VALUE2",
@@ -12467,7 +12467,7 @@
     "PS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "PS",
@@ -12480,7 +12480,7 @@
     "PS_STATUS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "PS_STATUS",
@@ -12493,7 +12493,7 @@
     "P_ALT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "P_ALT",
@@ -12506,7 +12506,7 @@
     "P_ALT_ST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "P_ALT_ST",
@@ -12519,7 +12519,7 @@
     "P_ALT_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "P_ALT_ST1",
@@ -12532,7 +12532,7 @@
     "P_ALT_VAL": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "P_ALT_VAL",
@@ -12545,7 +12545,7 @@
     "PageFPBUILD": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "PageFPBUILD",
@@ -12558,7 +12558,7 @@
     "PageNameACCREJ": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ"
             ],
             "id": "PageNameACCREJ",
@@ -12571,7 +12571,7 @@
     "PageNameALIGN": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN"
             ],
             "id": "PageNameALIGN",
@@ -12584,7 +12584,7 @@
     "PageNameALTALGN": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALTALGN"
             ],
             "id": "PageNameALTALGN",
@@ -12597,7 +12597,7 @@
     "PageNameANCHOR": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "PageNameANCHOR",
@@ -12610,7 +12610,7 @@
     "PageNameATTRIB": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "PageNameATTRIB",
@@ -12623,7 +12623,7 @@
     "PageNameBBCTL": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "BBCTL"
             ],
             "id": "PageNameBBCTL",
@@ -12636,7 +12636,7 @@
     "PageNameBITBALL": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "BITBALL"
             ],
             "id": "PageNameBITBALL",
@@ -12649,7 +12649,7 @@
     "PageNameCADC": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "PageNameCADC",
@@ -12662,7 +12662,7 @@
     "PageNameCDUTEST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "PageNameCDUTEST1",
@@ -12675,7 +12675,7 @@
     "PageNameCDUTEST2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST2"
             ],
             "id": "PageNameCDUTEST2",
@@ -12688,7 +12688,7 @@
     "PageNameDIVERT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DIVERT"
             ],
             "id": "PageNameDIVERT",
@@ -12701,7 +12701,7 @@
     "PageNameDTS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "PageNameDTS",
@@ -12714,7 +12714,7 @@
     "PageNameDTSAS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "PageNameDTSAS",
@@ -12727,7 +12727,7 @@
     "PageNameDTSDNLD": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSDNLD"
             ],
             "id": "PageNameDTSDNLD",
@@ -12740,7 +12740,7 @@
     "PageNameDTSSTAT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSSTAT"
             ],
             "id": "PageNameDTSSTAT",
@@ -12753,7 +12753,7 @@
     "PageNameDTSUPLD": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSUPLD"
             ],
             "id": "PageNameDTSUPLD",
@@ -12766,7 +12766,7 @@
     "PageNameEGI": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1",
                 "EGI2",
                 "EGI3",
@@ -12782,7 +12782,7 @@
     "PageNameEGITEST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "PageNameEGITEST",
@@ -12795,7 +12795,7 @@
     "PageNameFLDINFO": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "PageNameFLDINFO",
@@ -12808,7 +12808,7 @@
     "PageNameFPBUILD": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "PageNameFPBUILD",
@@ -12821,7 +12821,7 @@
     "PageNameFPMENU": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPMENU"
             ],
             "id": "PageNameFPMENU",
@@ -12834,7 +12834,7 @@
     "PageNameFROM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FROM"
             ],
             "id": "PageNameFROM",
@@ -12847,7 +12847,7 @@
     "PageNameGPS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "PageNameGPS",
@@ -12860,7 +12860,7 @@
     "PageNameGPSBIT1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT1"
             ],
             "id": "PageNameGPSBIT1",
@@ -12873,7 +12873,7 @@
     "PageNameGPSBIT2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT2"
             ],
             "id": "PageNameGPSBIT2",
@@ -12886,7 +12886,7 @@
     "PageNameGPSBIT3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT3"
             ],
             "id": "PageNameGPSBIT3",
@@ -12899,7 +12899,7 @@
     "PageNameGPSBIT4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT4"
             ],
             "id": "PageNameGPSBIT4",
@@ -12912,7 +12912,7 @@
     "PageNameGPSBIT5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSBIT5"
             ],
             "id": "PageNameGPSBIT5",
@@ -12925,7 +12925,7 @@
     "PageNameGPSKEYS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSKEYS"
             ],
             "id": "PageNameGPSKEYS",
@@ -12938,7 +12938,7 @@
     "PageNameGPSSTAT1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "PageNameGPSSTAT1",
@@ -12951,7 +12951,7 @@
     "PageNameHARS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "PageNameHARS",
@@ -12964,7 +12964,7 @@
     "PageNameINS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INS"
             ],
             "id": "PageNameINS",
@@ -12977,7 +12977,7 @@
     "PageNameINSSTAT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "PageNameINSSTAT",
@@ -12990,7 +12990,7 @@
     "PageNameLASTE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "PageNameLASTE",
@@ -13003,7 +13003,7 @@
     "PageNameLRUTEST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "PageNameLRUTEST",
@@ -13016,7 +13016,7 @@
     "PageNameMXLOG": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "MXLOG"
             ],
             "id": "PageNameMXLOG",
@@ -13029,7 +13029,7 @@
     "PageNameNAV": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "NAV"
             ],
             "id": "PageNameNAV",
@@ -13042,7 +13042,7 @@
     "PageNameOFFSET": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "PageNameOFFSET",
@@ -13055,7 +13055,7 @@
     "PageNameOFPID1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID1"
             ],
             "id": "PageNameOFPID1",
@@ -13068,7 +13068,7 @@
     "PageNameOFPID2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OFPID2"
             ],
             "id": "PageNameOFPID2",
@@ -13081,7 +13081,7 @@
     "PageNameOPTIONS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "OPTIONS"
             ],
             "id": "PageNameOPTIONS",
@@ -13094,7 +13094,7 @@
     "PageNamePOS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POS"
             ],
             "id": "PageNamePOS",
@@ -13107,7 +13107,7 @@
     "PageNamePOSINFO": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "PageNamePOSINFO",
@@ -13120,7 +13120,7 @@
     "PageNameREINIT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "PageNameREINIT",
@@ -13133,7 +13133,7 @@
     "PageNameRESET": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "PageNameRESET",
@@ -13146,7 +13146,7 @@
     "PageNameSTARTUPBIT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "PageNameSTARTUPBIT",
@@ -13159,7 +13159,7 @@
     "PageNameSTRINFO": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "PageNameSTRINFO",
@@ -13172,7 +13172,7 @@
     "PageNameSYS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS"
             ],
             "id": "PageNameSYS",
@@ -13185,7 +13185,7 @@
     "PageNameTIME": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "PageNameTIME",
@@ -13198,7 +13198,7 @@
     "PageNameUPDATE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "PageNameUPDATE",
@@ -13211,7 +13211,7 @@
     "PageNameWAYPT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT"
             ],
             "id": "PageNameWAYPT",
@@ -13224,7 +13224,7 @@
     "PageNameWIND": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "PageNameWIND",
@@ -13237,7 +13237,7 @@
     "PageNameWNDEDIT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT"
             ],
             "id": "PageNameWNDEDIT",
@@ -13250,7 +13250,7 @@
     "PageNameWPINFO": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "PageNameWPINFO",
@@ -13263,7 +13263,7 @@
     "PageNameWPMENU": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPMENU"
             ],
             "id": "PageNameWPMENU",
@@ -13276,7 +13276,7 @@
     "PageNameWPTATT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "PageNameWPTATT",
@@ -13289,7 +13289,7 @@
     "PresPositLat": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO",
                 "POS"
             ],
@@ -13303,7 +13303,7 @@
     "PresPositLat1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO",
                 "POS"
             ],
@@ -13317,7 +13317,7 @@
     "PresPositLong": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO",
                 "POS"
             ],
@@ -13331,7 +13331,7 @@
     "PresPositLong1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO",
                 "POS"
             ],
@@ -13345,7 +13345,7 @@
     "PresPositMGRS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO",
                 "POS"
             ],
@@ -13359,7 +13359,7 @@
     "PresPositMGRS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO",
                 "POS"
             ],
@@ -13373,7 +13373,7 @@
     "PresPositUTM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO",
                 "POS"
             ],
@@ -13387,7 +13387,7 @@
     "PresPositUTM1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO",
                 "POS"
             ],
@@ -13401,7 +13401,7 @@
     "RAM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "RAM",
@@ -13412,7 +13412,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "RAM",
@@ -13425,7 +13425,7 @@
     "RAM_1553": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "RAM_1553",
@@ -13436,7 +13436,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "RAM_1553",
@@ -13449,7 +13449,7 @@
     "READY": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "READY",
@@ -13460,7 +13460,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "READY",
@@ -13473,7 +13473,7 @@
     "READY_ST0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "READY_ST0",
@@ -13486,7 +13486,7 @@
     "READY_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "READY_ST1",
@@ -13499,7 +13499,7 @@
     "READY_ST2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "READY_ST2",
@@ -13512,7 +13512,7 @@
     "READY_ST3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "READY_ST3",
@@ -13525,7 +13525,7 @@
     "READY_ST4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTS"
             ],
             "id": "READY_ST4",
@@ -13538,7 +13538,7 @@
     "RECENT_NAV": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSUPLD"
             ],
             "id": "RECENT_NAV",
@@ -13551,7 +13551,7 @@
     "RECORD": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "RECORD",
@@ -13564,7 +13564,7 @@
     "REINIT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1"
             ],
             "id": "REINIT",
@@ -13577,7 +13577,7 @@
     "REINIT_DTSAS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "REINIT_DTSAS",
@@ -13590,7 +13590,7 @@
     "REINIT_GPS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "REINIT_GPS",
@@ -13603,7 +13603,7 @@
     "REINIT_INS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "REINIT_INS",
@@ -13616,7 +13616,7 @@
     "REINIT_LASTE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "REINIT"
             ],
             "id": "REINIT_LASTE",
@@ -13629,7 +13629,7 @@
     "REJECT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ"
             ],
             "id": "REJECT",
@@ -13642,7 +13642,7 @@
     "RESET": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "SYS1",
                 "BBCTL"
             ],
@@ -13656,7 +13656,7 @@
     "RESET_CADC": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "RESET_CADC",
@@ -13669,7 +13669,7 @@
     "RESET_CICU": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "RESET_CICU",
@@ -13682,7 +13682,7 @@
     "RESET_CICU0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "RESET_CICU0",
@@ -13695,7 +13695,7 @@
     "RESET_CICU1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "RESET_CICU1",
@@ -13708,7 +13708,7 @@
     "RESET_DTS": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "RESET_DTS",
@@ -13721,7 +13721,7 @@
     "RESET_EGI": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "RESET_EGI",
@@ -13734,7 +13734,7 @@
     "RESET_HARS": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "RESET_HARS",
@@ -13747,7 +13747,7 @@
     "RESET_LASTE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "RESET_LASTE",
@@ -13760,7 +13760,7 @@
     "RESET_LASTE1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "RESET_LASTE1",
@@ -13773,7 +13773,7 @@
     "RESET_ST0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "RESET_ST0",
@@ -13786,7 +13786,7 @@
     "RESET_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "RESET"
             ],
             "id": "RESET_ST1",
@@ -13799,7 +13799,7 @@
     "ROLL": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "ROLL",
@@ -13812,7 +13812,7 @@
     "ROLL_ST2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "ROLL_ST2",
@@ -13825,7 +13825,7 @@
     "ROLL_ST3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "ROLL_ST3",
@@ -13838,7 +13838,7 @@
     "ROLL_VAL": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "HARS"
             ],
             "id": "ROLL_VAL",
@@ -13851,7 +13851,7 @@
     "RPU": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "RPU",
@@ -13864,7 +13864,7 @@
     "RPU4s": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "RPU4s",
@@ -13877,7 +13877,7 @@
     "RPU4s1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "RPU4s1",
@@ -13890,7 +13890,7 @@
     "RTR": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ",
                 "UPDATE"
             ],
@@ -13904,7 +13904,7 @@
     "RT_ADDR": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "RT_ADDR",
@@ -13917,7 +13917,7 @@
     "RWY": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "RWY",
@@ -13930,7 +13930,7 @@
     "RWY_L_FEET": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "RWY_L_FEET",
@@ -13943,7 +13943,7 @@
     "SAT4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "SAT4",
@@ -13956,7 +13956,7 @@
     "SAT4s": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "SAT4s",
@@ -13969,7 +13969,7 @@
     "SAT4s1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "SAT4s1",
@@ -13982,7 +13982,7 @@
     "SCALE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT",
                 "WAYPT2"
             ],
@@ -13994,7 +13994,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "SCALE",
@@ -14007,7 +14007,7 @@
     "SCS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "SCS",
@@ -14020,7 +14020,7 @@
     "SCS_ROTARY": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "SCS_ROTARY",
@@ -14033,7 +14033,7 @@
     "SENSORS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "SENSORS",
@@ -14046,7 +14046,7 @@
     "SEN_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "SEN_ST1",
@@ -14059,7 +14059,7 @@
     "SEN_ST2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "INSSTAT"
             ],
             "id": "SEN_ST2",
@@ -14072,7 +14072,7 @@
     "SERVICE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "SERVICE",
@@ -14085,7 +14085,7 @@
     "SFKEYSs": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "SFKEYSs",
@@ -14098,7 +14098,7 @@
     "SFKEYSs1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "SFKEYSs1",
@@ -14111,7 +14111,7 @@
     "SFKEYSs2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "SFKEYSs2",
@@ -14124,7 +14124,7 @@
     "SLASH1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "SLASH1",
@@ -14137,7 +14137,7 @@
     "SLASH2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "SLASH2",
@@ -14150,7 +14150,7 @@
     "SPHEROID": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPMENU"
             ],
             "id": "SPHEROID",
@@ -14163,7 +14163,7 @@
     "SPU": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "SPU",
@@ -14176,7 +14176,7 @@
     "SPU_STATUS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "SPU_STATUS",
@@ -14189,7 +14189,7 @@
     "ST3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "ST3",
@@ -14202,7 +14202,7 @@
     "ST5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "ST5",
@@ -14215,7 +14215,7 @@
     "START": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "START",
@@ -14228,7 +14228,7 @@
     "STARTUPBIT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT",
@@ -14241,7 +14241,7 @@
     "STARTUPBIT1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT1",
@@ -14254,7 +14254,7 @@
     "STARTUPBIT10": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT10",
@@ -14267,7 +14267,7 @@
     "STARTUPBIT11": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT11",
@@ -14280,7 +14280,7 @@
     "STARTUPBIT12": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT12",
@@ -14293,7 +14293,7 @@
     "STARTUPBIT13": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT13",
@@ -14306,7 +14306,7 @@
     "STARTUPBIT14": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT14",
@@ -14319,7 +14319,7 @@
     "STARTUPBIT15": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT15",
@@ -14332,7 +14332,7 @@
     "STARTUPBIT16": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT16",
@@ -14345,7 +14345,7 @@
     "STARTUPBIT17": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT17",
@@ -14358,7 +14358,7 @@
     "STARTUPBIT18": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT18",
@@ -14371,7 +14371,7 @@
     "STARTUPBIT19": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT19",
@@ -14384,7 +14384,7 @@
     "STARTUPBIT2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT2",
@@ -14397,7 +14397,7 @@
     "STARTUPBIT20": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT20",
@@ -14410,7 +14410,7 @@
     "STARTUPBIT21": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT21",
@@ -14423,7 +14423,7 @@
     "STARTUPBIT22": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT22",
@@ -14436,7 +14436,7 @@
     "STARTUPBIT23": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT23",
@@ -14449,7 +14449,7 @@
     "STARTUPBIT24": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT24",
@@ -14462,7 +14462,7 @@
     "STARTUPBIT3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT3",
@@ -14475,7 +14475,7 @@
     "STARTUPBIT4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT4",
@@ -14488,7 +14488,7 @@
     "STARTUPBIT5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT5",
@@ -14501,7 +14501,7 @@
     "STARTUPBIT6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT6",
@@ -14514,7 +14514,7 @@
     "STARTUPBIT7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT7",
@@ -14527,7 +14527,7 @@
     "STARTUPBIT8": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT8",
@@ -14540,7 +14540,7 @@
     "STARTUPBIT9": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STARTUP_BIT"
             ],
             "id": "STARTUPBIT9",
@@ -14553,7 +14553,7 @@
     "START_SA": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "CDUTEST1"
             ],
             "id": "START_SA",
@@ -14566,7 +14566,7 @@
     "STATUS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI2"
             ],
             "id": "STATUS",
@@ -14579,7 +14579,7 @@
     "STATUS_LINE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "STATUS_LINE",
@@ -14592,7 +14592,7 @@
     "STATUS_LINE1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "STATUS_LINE1",
@@ -14605,7 +14605,7 @@
     "STATUS_LINE2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI1"
             ],
             "id": "STATUS_LINE2",
@@ -14618,7 +14618,7 @@
     "STEER": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT",
                 "WAYPT2"
             ],
@@ -14630,7 +14630,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "STEER",
@@ -14643,7 +14643,7 @@
     "STEERPOINT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPMENU"
             ],
             "id": "STEERPOINT",
@@ -14656,7 +14656,7 @@
     "STEERPTIndicator": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "STEERPTIndicator",
@@ -14669,7 +14669,7 @@
     "STEER_PT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "STEER_PT",
@@ -14682,7 +14682,7 @@
     "STOP_MSN": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "STOP_MSN",
@@ -14695,7 +14695,7 @@
     "STOP_SA": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGITEST"
             ],
             "id": "STOP_SA",
@@ -14708,7 +14708,7 @@
     "STRBRGRAD": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRBRGRAD",
@@ -14721,7 +14721,7 @@
     "STRBRGRAD1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRBRGRAD1",
@@ -14734,7 +14734,7 @@
     "STRBRGRAD2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRBRGRAD2",
@@ -14747,7 +14747,7 @@
     "STRBRGRAD3": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRBRGRAD3",
@@ -14760,7 +14760,7 @@
     "STRBRGRAD4": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRBRGRAD4",
@@ -14773,7 +14773,7 @@
     "STRBRGRADMode": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRBRGRADMode",
@@ -14786,7 +14786,7 @@
     "STRBRGRADMode1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRBRGRADMode1",
@@ -14799,7 +14799,7 @@
     "STRBRGRADRotary": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRBRGRADRotary",
@@ -14812,7 +14812,7 @@
     "STRDIS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRDIS",
@@ -14823,7 +14823,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ"
             ],
             "id": "STRDIS",
@@ -14834,7 +14834,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "STRDIS",
@@ -14847,7 +14847,7 @@
     "STRDIS1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRDIS1",
@@ -14858,7 +14858,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "STRDIS1",
@@ -14869,7 +14869,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "STRDIS1",
@@ -14880,7 +14880,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "STRDIS1",
@@ -14893,7 +14893,7 @@
     "STRDIS2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRDIS2",
@@ -14904,7 +14904,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "STRDIS2",
@@ -14915,7 +14915,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "STRDIS2",
@@ -14928,7 +14928,7 @@
     "STRDIS3": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRDIS3",
@@ -14939,7 +14939,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "STRDIS3",
@@ -14952,7 +14952,7 @@
     "STRDISMH": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "STRDISMH",
@@ -14965,7 +14965,7 @@
     "STRDMH": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRDMH",
@@ -14978,7 +14978,7 @@
     "STRDMH1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRDMH1",
@@ -14989,7 +14989,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "STRDMH1",
@@ -15002,7 +15002,7 @@
     "STRDMH2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRDMH2",
@@ -15013,7 +15013,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "STRDMH2",
@@ -15026,7 +15026,7 @@
     "STRDMH3": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRDMH3",
@@ -15037,7 +15037,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "STRDMH3",
@@ -15050,7 +15050,7 @@
     "STREL": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STREL",
@@ -15061,7 +15061,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ",
                 "UPDATE"
             ],
@@ -15075,7 +15075,7 @@
     "STREL1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STREL1",
@@ -15086,7 +15086,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "STREL1",
@@ -15099,7 +15099,7 @@
     "STREL2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STREL2",
@@ -15110,7 +15110,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "STREL2",
@@ -15123,7 +15123,7 @@
     "STREL3": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STREL3",
@@ -15134,7 +15134,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ",
                 "UPDATE"
             ],
@@ -15148,7 +15148,7 @@
     "STREL4": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STREL4",
@@ -15161,7 +15161,7 @@
     "STRGroundSpeed1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRGroundSpeed1",
@@ -15174,7 +15174,7 @@
     "STRIAS1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRIAS1",
@@ -15187,7 +15187,7 @@
     "STRIdent": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRIdent",
@@ -15198,7 +15198,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "STRIdent",
@@ -15211,7 +15211,7 @@
     "STRIdent1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO",
                 "ANCHOR"
             ],
@@ -15223,7 +15223,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "STRIdent1",
@@ -15236,7 +15236,7 @@
     "STRIdent2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO",
                 "ANCHOR"
             ],
@@ -15250,7 +15250,7 @@
     "STRIdent3": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "STRIdent3",
@@ -15263,7 +15263,7 @@
     "STRIdentEntry": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO",
                 "ANCHOR"
             ],
@@ -15277,7 +15277,7 @@
     "STRMH1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "STRMH1",
@@ -15290,7 +15290,7 @@
     "STRMH2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "STRMH2",
@@ -15303,7 +15303,7 @@
     "STRNumber": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO",
                 "UPDATE"
             ],
@@ -15317,7 +15317,7 @@
     "STRNumber1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO",
                 "UPDATE"
             ],
@@ -15331,7 +15331,7 @@
     "STRNumber2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRNumber2",
@@ -15344,7 +15344,7 @@
     "STRNumber3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRNumber3",
@@ -15357,7 +15357,7 @@
     "STRNumberIncDec": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRNumberIncDec",
@@ -15370,7 +15370,7 @@
     "STRReqGroundSpeed": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRReqGroundSpeed",
@@ -15383,7 +15383,7 @@
     "STRReqIAS": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRReqIAS",
@@ -15396,7 +15396,7 @@
     "STRReqSpeedMode": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRReqSpeedMode",
@@ -15409,7 +15409,7 @@
     "STRReqSpeedMode1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRReqSpeedMode1",
@@ -15422,7 +15422,7 @@
     "STRReqSpeedMode2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRReqSpeedMode2",
@@ -15435,7 +15435,7 @@
     "STRReqSpeedRotary": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRReqSpeedRotary",
@@ -15448,7 +15448,7 @@
     "STRReqTAS": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRReqTAS",
@@ -15461,7 +15461,7 @@
     "STRSpeedMode3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRSpeedMode3",
@@ -15474,7 +15474,7 @@
     "STRSpeedMode4": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRSpeedMode4",
@@ -15487,7 +15487,7 @@
     "STRSpeedMode5": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRSpeedMode5",
@@ -15500,7 +15500,7 @@
     "STRSpeedMode6": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRSpeedMode6",
@@ -15513,7 +15513,7 @@
     "STRSpeedRotary1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRSpeedRotary1",
@@ -15526,7 +15526,7 @@
     "STRTAS1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRTAS1",
@@ -15539,7 +15539,7 @@
     "STRTOT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRTOT",
@@ -15552,7 +15552,7 @@
     "STRTOT1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRTOT1",
@@ -15565,7 +15565,7 @@
     "STRTOT2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRTOT2",
@@ -15578,7 +15578,7 @@
     "STRTOT3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRTOT3",
@@ -15591,7 +15591,7 @@
     "STRTOT4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRTOT4",
@@ -15604,7 +15604,7 @@
     "STRTTG": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRTTG",
@@ -15615,7 +15615,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "STRTTG",
@@ -15628,7 +15628,7 @@
     "STRTTG1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRTTG1",
@@ -15639,7 +15639,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "STRTTG1",
@@ -15650,7 +15650,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "STRTTG1",
@@ -15661,7 +15661,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "STRTTG1",
@@ -15674,7 +15674,7 @@
     "STRTTG2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRTTG2",
@@ -15685,7 +15685,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "STRTTG2",
@@ -15696,7 +15696,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "STRTTG2",
@@ -15707,7 +15707,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "STRTTG2",
@@ -15720,7 +15720,7 @@
     "STRTTG3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRTTG3",
@@ -15731,7 +15731,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "STRTTG3",
@@ -15742,7 +15742,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "UPDATE"
             ],
             "id": "STRTTG3",
@@ -15753,7 +15753,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "STRTTG3",
@@ -15766,7 +15766,7 @@
     "STRTTG4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRTTG4",
@@ -15777,7 +15777,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "STRTTG4",
@@ -15790,7 +15790,7 @@
     "STRTTG5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRTTG5",
@@ -15801,7 +15801,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "STRTTG5",
@@ -15814,7 +15814,7 @@
     "STRWindDirection1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRWindDirection1",
@@ -15827,7 +15827,7 @@
     "STRWindDirection2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRWindDirection2",
@@ -15840,7 +15840,7 @@
     "STRWindSpeed1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRWindSpeed1",
@@ -15853,7 +15853,7 @@
     "STRWindSpeed2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "STRWindSpeed2",
@@ -15866,7 +15866,7 @@
     "ST_ST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSSTAT"
             ],
             "id": "ST_ST",
@@ -15879,7 +15879,7 @@
     "SUCCESSFUL": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "SUCCESSFUL",
@@ -15892,7 +15892,7 @@
     "SUFKEYS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "SUFKEYS",
@@ -15905,7 +15905,7 @@
     "T": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ALIGN",
                 "ALTALGN"
             ],
@@ -15919,7 +15919,7 @@
     "TAC": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FLDINFO"
             ],
             "id": "TAC",
@@ -15932,7 +15932,7 @@
     "TARGET_MARK": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "OFFSET"
             ],
             "id": "TARGET_MARK",
@@ -15945,7 +15945,7 @@
     "TAS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "TAS",
@@ -15958,7 +15958,7 @@
     "TAS_ST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "TAS_ST",
@@ -15971,7 +15971,7 @@
     "TAS_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "TAS_ST1",
@@ -15984,7 +15984,7 @@
     "TAS_VAL": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "TAS_VAL",
@@ -15997,7 +15997,7 @@
     "TEMP": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "TEMP",
@@ -16010,7 +16010,7 @@
     "TEMP_ST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "TEMP_ST",
@@ -16023,7 +16023,7 @@
     "TEMP_ST1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "TEMP_ST1",
@@ -16036,7 +16036,7 @@
     "TEMP_VAL": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "CADC"
             ],
             "id": "TEMP_VAL",
@@ -16049,7 +16049,7 @@
     "TEST_MODE0": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "TEST_MODE0",
@@ -16062,7 +16062,7 @@
     "TEST_MODE1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "TEST_MODE1",
@@ -16075,7 +16075,7 @@
     "TEST_MODE2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "TEST_MODE2",
@@ -16088,7 +16088,7 @@
     "TEST_MODE4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "TEST_MODE4",
@@ -16101,7 +16101,7 @@
     "TEST_SA": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "TEST_SA",
@@ -16114,7 +16114,7 @@
     "TEST_SA1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "TEST_SA1",
@@ -16127,7 +16127,7 @@
     "TEST_SA2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LRUTEST"
             ],
             "id": "TEST_SA2",
@@ -16140,7 +16140,7 @@
     "TGTSYM_NEW_WPT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "TGTSYM_NEW_WPT",
@@ -16153,7 +16153,7 @@
     "TIME": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "NAV"
             ],
             "id": "TIME",
@@ -16164,7 +16164,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "BITBALL"
             ],
             "id": "TIME",
@@ -16175,7 +16175,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "GPS"
             ],
             "id": "TIME",
@@ -16188,7 +16188,7 @@
     "TOT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "TOT",
@@ -16201,7 +16201,7 @@
     "TTG": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ANCHOR"
             ],
             "id": "TTG",
@@ -16214,7 +16214,7 @@
     "TempC": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "TempC",
@@ -16227,7 +16227,7 @@
     "TempF": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "TempF",
@@ -16240,7 +16240,7 @@
     "TempRotary": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "POSINFO"
             ],
             "id": "TempRotary",
@@ -16253,7 +16253,7 @@
     "UPDATE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "NAV"
             ],
             "id": "UPDATE",
@@ -16264,7 +16264,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "INS"
             ],
             "id": "UPDATE",
@@ -16277,7 +16277,7 @@
     "UTC": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "UTC",
@@ -16290,7 +16290,7 @@
     "UTCs": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "UTCs",
@@ -16303,7 +16303,7 @@
     "UTCs1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT1"
             ],
             "id": "UTCs1",
@@ -16316,7 +16316,7 @@
     "VANGLE": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT",
                 "WAYPT2"
             ],
@@ -16328,7 +16328,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "VANGLE",
@@ -16341,7 +16341,7 @@
     "VANGLEEntry": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT",
                 "WAYPT2"
             ],
@@ -16353,7 +16353,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "VANGLEEntry",
@@ -16366,7 +16366,7 @@
     "VANGLEMode": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT",
                 "WAYPT2"
             ],
@@ -16378,7 +16378,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "VANGLEMode",
@@ -16391,7 +16391,7 @@
     "VANGLEMode1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT",
                 "WAYPT2"
             ],
@@ -16403,7 +16403,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "VANGLEMode1",
@@ -16416,7 +16416,7 @@
     "VANGLEValue": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT",
                 "WAYPT2"
             ],
@@ -16428,7 +16428,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "VANGLEValue",
@@ -16441,7 +16441,7 @@
     "VIEW1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "BBCTL"
             ],
             "id": "VIEW1",
@@ -16454,7 +16454,7 @@
     "VIEW2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "BBCTL"
             ],
             "id": "VIEW2",
@@ -16467,7 +16467,7 @@
     "VIEW3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "BBCTL"
             ],
             "id": "VIEW3",
@@ -16480,7 +16480,7 @@
     "VIEW4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "BBCTL"
             ],
             "id": "VIEW4",
@@ -16493,7 +16493,7 @@
     "VIEW5": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "BBCTL"
             ],
             "id": "VIEW5",
@@ -16506,7 +16506,7 @@
     "VNAV_MODE": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT",
                 "WAYPT2"
             ],
@@ -16518,7 +16518,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ATTRIB"
             ],
             "id": "VNAV_MODE",
@@ -16531,7 +16531,7 @@
     "VPU": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSAS"
             ],
             "id": "VPU",
@@ -16544,7 +16544,7 @@
     "VRSN": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "DTSSTAT"
             ],
             "id": "VRSN",
@@ -16557,7 +16557,7 @@
     "WARCODE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI3",
                 "EGI4"
             ],
@@ -16571,7 +16571,7 @@
     "WARNING": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "EGI3",
                 "EGI4"
             ],
@@ -16585,7 +16585,7 @@
     "WAYPOINT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO"
             ],
             "id": "WAYPOINT",
@@ -16596,7 +16596,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "WAYPOINT",
@@ -16607,7 +16607,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPMENU"
             ],
             "id": "WAYPOINT",
@@ -16620,7 +16620,7 @@
     "WAYPTClass": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass",
@@ -16633,7 +16633,7 @@
     "WAYPTClass1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass1",
@@ -16646,7 +16646,7 @@
     "WAYPTClass10": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass10",
@@ -16659,7 +16659,7 @@
     "WAYPTClass11": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass11",
@@ -16672,7 +16672,7 @@
     "WAYPTClass12": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass12",
@@ -16685,7 +16685,7 @@
     "WAYPTClass13": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass13",
@@ -16698,7 +16698,7 @@
     "WAYPTClass14": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass14",
@@ -16711,7 +16711,7 @@
     "WAYPTClass15": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass15",
@@ -16724,7 +16724,7 @@
     "WAYPTClass16": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass16",
@@ -16737,7 +16737,7 @@
     "WAYPTClass17": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass17",
@@ -16750,7 +16750,7 @@
     "WAYPTClass18": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass18",
@@ -16763,7 +16763,7 @@
     "WAYPTClass19": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass19",
@@ -16776,7 +16776,7 @@
     "WAYPTClass2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass2",
@@ -16789,7 +16789,7 @@
     "WAYPTClass20": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass20",
@@ -16802,7 +16802,7 @@
     "WAYPTClass21": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass21",
@@ -16815,7 +16815,7 @@
     "WAYPTClass3": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass3",
@@ -16828,7 +16828,7 @@
     "WAYPTClass4": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass4",
@@ -16841,7 +16841,7 @@
     "WAYPTClass5": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass5",
@@ -16854,7 +16854,7 @@
     "WAYPTClass6": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass6",
@@ -16867,7 +16867,7 @@
     "WAYPTClass7": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass7",
@@ -16880,7 +16880,7 @@
     "WAYPTClass8": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass8",
@@ -16893,7 +16893,7 @@
     "WAYPTClass9": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTClass9",
@@ -16906,7 +16906,7 @@
     "WAYPTCoordFormat": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTCoordFormat",
@@ -16919,7 +16919,7 @@
     "WAYPTCoordFormat1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTCoordFormat1",
@@ -16932,7 +16932,7 @@
     "WAYPTDATA_ENTRY": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTDATA_ENTRY",
@@ -16945,7 +16945,7 @@
     "WAYPTDATA_ENTRY1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTDATA_ENTRY1",
@@ -16958,7 +16958,7 @@
     "WAYPTIdent": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTIdent",
@@ -16969,7 +16969,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTIdent",
@@ -16982,7 +16982,7 @@
     "WAYPTIdent1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO",
                 "WAYPT1"
             ],
@@ -16994,7 +16994,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTIdent1",
@@ -17007,7 +17007,7 @@
     "WAYPTIdent2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "WAYPTIdent2",
@@ -17020,7 +17020,7 @@
     "WAYPTLat": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ",
                 "UPDATE",
                 "WAYPT1"
@@ -17035,7 +17035,7 @@
     "WAYPTLatUTM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ",
                 "UPDATE",
                 "WAYPT1"
@@ -17050,7 +17050,7 @@
     "WAYPTLong": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ",
                 "UPDATE",
                 "WAYPT1"
@@ -17065,7 +17065,7 @@
     "WAYPTLongMGRS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ",
                 "UPDATE",
                 "WAYPT1"
@@ -17080,7 +17080,7 @@
     "WAYPTMGRS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ",
                 "UPDATE",
                 "WAYPT1"
@@ -17095,7 +17095,7 @@
     "WAYPTNumber": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTNumber",
@@ -17106,7 +17106,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTNumber",
@@ -17119,7 +17119,7 @@
     "WAYPTNumber1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO",
                 "WAYPT1"
             ],
@@ -17131,7 +17131,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTNumber1",
@@ -17144,7 +17144,7 @@
     "WAYPTNumber2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "WAYPTNumber2",
@@ -17157,7 +17157,7 @@
     "WAYPTScale": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTScale",
@@ -17170,7 +17170,7 @@
     "WAYPTScale1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTScale1",
@@ -17183,7 +17183,7 @@
     "WAYPTScale2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTScale2",
@@ -17196,7 +17196,7 @@
     "WAYPTScale3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTScale3",
@@ -17209,7 +17209,7 @@
     "WAYPTScale4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTScale4",
@@ -17222,7 +17222,7 @@
     "WAYPTSteer": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTSteer",
@@ -17235,7 +17235,7 @@
     "WAYPTSteer1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTSteer1",
@@ -17248,7 +17248,7 @@
     "WAYPTSteer2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTSteer2",
@@ -17261,7 +17261,7 @@
     "WAYPTSteer4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTSteer4",
@@ -17274,7 +17274,7 @@
     "WAYPTUTM": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ",
                 "UPDATE",
                 "WAYPT1"
@@ -17289,7 +17289,7 @@
     "WAYPTVNavMode": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTVNavMode",
@@ -17302,7 +17302,7 @@
     "WAYPTVNavMode1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTVNavMode1",
@@ -17315,7 +17315,7 @@
     "WAYPTVNavMode2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPTVNavMode2",
@@ -17328,7 +17328,7 @@
     "WAYPTWindDirection1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTWindDirection1",
@@ -17341,7 +17341,7 @@
     "WAYPTWindDirection2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTWindDirection2",
@@ -17354,7 +17354,7 @@
     "WAYPTWindSpeed1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTWindSpeed1",
@@ -17367,7 +17367,7 @@
     "WAYPTWindSpeed2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPTWindSpeed2",
@@ -17380,7 +17380,7 @@
     "WAYPT_CR_FLAG": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPT_CR_FLAG",
@@ -17393,7 +17393,7 @@
     "WAYPT_CR_FLAG1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPT_CR_FLAG1",
@@ -17406,7 +17406,7 @@
     "WAYPT_DTOT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPT_DTOT",
@@ -17417,7 +17417,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPT_DTOT",
@@ -17430,7 +17430,7 @@
     "WAYPT_DTOT1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPT_DTOT1",
@@ -17441,7 +17441,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPT_DTOT1",
@@ -17454,7 +17454,7 @@
     "WAYPT_DTTG": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPT_DTTG",
@@ -17467,7 +17467,7 @@
     "WAYPT_DTTG1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT2"
             ],
             "id": "WAYPT_DTTG1",
@@ -17480,7 +17480,7 @@
     "WAYPT_EL1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPT_EL1",
@@ -17493,7 +17493,7 @@
     "WAYPT_EL2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPT_EL2",
@@ -17506,7 +17506,7 @@
     "WAYPT_EL3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WAYPT1"
             ],
             "id": "WAYPT_EL3",
@@ -17519,7 +17519,7 @@
     "WAYPT_INCR_DECR": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO",
                 "WAYPT1"
             ],
@@ -17533,7 +17533,7 @@
     "WE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ"
             ],
             "id": "WE",
@@ -17546,7 +17546,7 @@
     "WE_ERR": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "ACCREJ"
             ],
             "id": "WE_ERR",
@@ -17559,7 +17559,7 @@
     "WIND": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "WIND",
@@ -17570,7 +17570,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WIND",
@@ -17583,7 +17583,7 @@
     "WINDALT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDALT",
@@ -17594,7 +17594,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDALT",
@@ -17605,7 +17605,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDALT",
@@ -17616,7 +17616,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDALT",
@@ -17629,7 +17629,7 @@
     "WINDALT1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDALT1",
@@ -17640,7 +17640,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDALT1",
@@ -17651,7 +17651,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDALT1",
@@ -17662,7 +17662,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDALT1",
@@ -17675,7 +17675,7 @@
     "WINDALT2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDALT2",
@@ -17686,7 +17686,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDALT2",
@@ -17697,7 +17697,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDALT2",
@@ -17708,7 +17708,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDALT2",
@@ -17721,7 +17721,7 @@
     "WINDALT3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDALT3",
@@ -17732,7 +17732,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDALT3",
@@ -17745,7 +17745,7 @@
     "WINDCLRMODE": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "WINDCLRMODE",
@@ -17758,7 +17758,7 @@
     "WINDCLRMODE1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "WINDCLRMODE1",
@@ -17771,7 +17771,7 @@
     "WINDCLRMODE2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "WINDCLRMODE2",
@@ -17784,7 +17784,7 @@
     "WINDDATA_ENTRY": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDDATA_ENTRY",
@@ -17795,7 +17795,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDATA_ENTRY",
@@ -17808,7 +17808,7 @@
     "WINDDATA_ENTRY1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDDATA_ENTRY1",
@@ -17819,7 +17819,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDATA_ENTRY1",
@@ -17832,7 +17832,7 @@
     "WINDDATA_ENTRY2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDDATA_ENTRY2",
@@ -17843,7 +17843,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDATA_ENTRY2",
@@ -17856,7 +17856,7 @@
     "WINDDATA_ENTRY3": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDDATA_ENTRY3",
@@ -17867,7 +17867,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDATA_ENTRY3",
@@ -17880,7 +17880,7 @@
     "WINDDATA_ENTRY4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDDATA_ENTRY4",
@@ -17891,7 +17891,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDATA_ENTRY4",
@@ -17904,7 +17904,7 @@
     "WINDDATA_ENTRY5": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDDATA_ENTRY5",
@@ -17915,7 +17915,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDATA_ENTRY5",
@@ -17928,7 +17928,7 @@
     "WINDDATA_ENTRY6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDATA_ENTRY6",
@@ -17941,7 +17941,7 @@
     "WINDDATA_ENTRY7": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDATA_ENTRY7",
@@ -17954,7 +17954,7 @@
     "WINDDIV": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDDIV",
@@ -17965,7 +17965,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDDIV",
@@ -17976,7 +17976,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDDIV",
@@ -17987,7 +17987,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDIV",
@@ -18000,7 +18000,7 @@
     "WINDDIV1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDDIV1",
@@ -18011,7 +18011,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDDIV1",
@@ -18022,7 +18022,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDDIV1",
@@ -18033,7 +18033,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDIV1",
@@ -18046,7 +18046,7 @@
     "WINDDIV2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDDIV2",
@@ -18057,7 +18057,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDDIV2",
@@ -18068,7 +18068,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDDIV2",
@@ -18079,7 +18079,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDIV2",
@@ -18092,7 +18092,7 @@
     "WINDDIV3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDDIV3",
@@ -18103,7 +18103,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDIV3",
@@ -18116,7 +18116,7 @@
     "WINDDir": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDDir",
@@ -18129,7 +18129,7 @@
     "WINDDir1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDDir1",
@@ -18142,7 +18142,7 @@
     "WINDDirSpeed": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDDirSpeed",
@@ -18153,7 +18153,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDDirSpeed",
@@ -18164,7 +18164,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDDirSpeed",
@@ -18175,7 +18175,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDirSpeed",
@@ -18188,7 +18188,7 @@
     "WINDDirSpeed1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDDirSpeed1",
@@ -18199,7 +18199,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDDirSpeed1",
@@ -18210,7 +18210,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDDirSpeed1",
@@ -18221,7 +18221,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDirSpeed1",
@@ -18234,7 +18234,7 @@
     "WINDDirSpeed2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDDirSpeed2",
@@ -18245,7 +18245,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDDirSpeed2",
@@ -18256,7 +18256,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDDirSpeed2",
@@ -18267,7 +18267,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDirSpeed2",
@@ -18280,7 +18280,7 @@
     "WINDDirSpeed3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDDirSpeed3",
@@ -18291,7 +18291,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDDirSpeed3",
@@ -18302,7 +18302,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDDirSpeed3",
@@ -18313,7 +18313,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDirSpeed3",
@@ -18326,7 +18326,7 @@
     "WINDDirSpeed4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDDirSpeed4",
@@ -18337,7 +18337,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDDirSpeed4",
@@ -18348,7 +18348,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDirSpeed4",
@@ -18361,7 +18361,7 @@
     "WINDDirSpeed5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDDirSpeed5",
@@ -18372,7 +18372,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDDirSpeed5",
@@ -18383,7 +18383,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDirSpeed5",
@@ -18396,7 +18396,7 @@
     "WINDDirSpeed6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDDirSpeed6",
@@ -18407,7 +18407,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDirSpeed6",
@@ -18420,7 +18420,7 @@
     "WINDDirSpeed7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDDirSpeed7",
@@ -18431,7 +18431,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDDirSpeed7",
@@ -18444,7 +18444,7 @@
     "WINDMODE": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "WINDMODE",
@@ -18457,7 +18457,7 @@
     "WINDMODE1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "WINDMODE1",
@@ -18470,7 +18470,7 @@
     "WINDMODE2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "WINDMODE2",
@@ -18483,7 +18483,7 @@
     "WINDMODE3": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "WINDMODE3",
@@ -18496,7 +18496,7 @@
     "WINDMODE4": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "WINDMODE4",
@@ -18509,7 +18509,7 @@
     "WINDSpeed": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDSpeed",
@@ -18520,7 +18520,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDSpeed",
@@ -18531,7 +18531,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDSpeed",
@@ -18542,7 +18542,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDSpeed",
@@ -18555,7 +18555,7 @@
     "WINDSpeed1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDSpeed1",
@@ -18566,7 +18566,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDSpeed1",
@@ -18577,7 +18577,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDSpeed1",
@@ -18588,7 +18588,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDSpeed1",
@@ -18601,7 +18601,7 @@
     "WINDSpeed2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDSpeed2",
@@ -18612,7 +18612,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDSpeed2",
@@ -18623,7 +18623,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDSpeed2",
@@ -18634,7 +18634,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDSpeed2",
@@ -18647,7 +18647,7 @@
     "WINDSpeed3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDSpeed3",
@@ -18658,7 +18658,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDSpeed3",
@@ -18669,7 +18669,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDSpeed3",
@@ -18680,7 +18680,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDSpeed3",
@@ -18693,7 +18693,7 @@
     "WINDSpeed4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDSpeed4",
@@ -18704,7 +18704,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDSpeed4",
@@ -18715,7 +18715,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDSpeed4",
@@ -18726,7 +18726,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDSpeed4",
@@ -18739,7 +18739,7 @@
     "WINDSpeed5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDSpeed5",
@@ -18750,7 +18750,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDSpeed5",
@@ -18761,7 +18761,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDSpeed5",
@@ -18772,7 +18772,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDSpeed5",
@@ -18785,7 +18785,7 @@
     "WINDSpeed6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDSpeed6",
@@ -18796,7 +18796,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDSpeed6",
@@ -18809,7 +18809,7 @@
     "WINDSpeed7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDSpeed7",
@@ -18820,7 +18820,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDSpeed7",
@@ -18833,7 +18833,7 @@
     "WINDTemp": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WIND",
                 "WNDEDIT"
             ],
@@ -18845,7 +18845,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDTemp",
@@ -18856,7 +18856,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDTemp",
@@ -18867,7 +18867,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDTemp",
@@ -18878,7 +18878,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDTemp",
@@ -18891,7 +18891,7 @@
     "WINDTemp1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WIND",
                 "WNDEDIT"
             ],
@@ -18903,7 +18903,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDTemp1",
@@ -18914,7 +18914,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDTemp1",
@@ -18925,7 +18925,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDTemp1",
@@ -18936,7 +18936,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDTemp1",
@@ -18949,7 +18949,7 @@
     "WINDTemp10": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDTemp10",
@@ -18960,7 +18960,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDTemp10",
@@ -18973,7 +18973,7 @@
     "WINDTemp11": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDTemp11",
@@ -18984,7 +18984,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDTemp11",
@@ -18997,7 +18997,7 @@
     "WINDTemp12": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDTemp12",
@@ -19010,7 +19010,7 @@
     "WINDTemp2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDTemp2",
@@ -19021,7 +19021,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDTemp2",
@@ -19032,7 +19032,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDTemp2",
@@ -19043,7 +19043,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDTemp2",
@@ -19056,7 +19056,7 @@
     "WINDTemp3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDTemp3",
@@ -19067,7 +19067,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDTemp3",
@@ -19078,7 +19078,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDTemp3",
@@ -19091,7 +19091,7 @@
     "WINDTemp4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDTemp4",
@@ -19102,7 +19102,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDTemp4",
@@ -19113,7 +19113,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDTemp4",
@@ -19124,7 +19124,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDTemp4",
@@ -19137,7 +19137,7 @@
     "WINDTemp5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDTemp5",
@@ -19148,7 +19148,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDTemp5",
@@ -19159,7 +19159,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDTemp5",
@@ -19170,7 +19170,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDTemp5",
@@ -19183,7 +19183,7 @@
     "WINDTemp6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDTemp6",
@@ -19194,7 +19194,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDTemp6",
@@ -19205,7 +19205,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDTemp6",
@@ -19216,7 +19216,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDTemp6",
@@ -19229,7 +19229,7 @@
     "WINDTemp7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDTemp7",
@@ -19240,7 +19240,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDTemp7",
@@ -19251,7 +19251,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDTemp7",
@@ -19262,7 +19262,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDTemp7",
@@ -19275,7 +19275,7 @@
     "WINDTemp8": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND1"
             ],
             "id": "WINDTemp8",
@@ -19286,7 +19286,7 @@
         },
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDTemp8",
@@ -19297,7 +19297,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WINDTemp8",
@@ -19308,7 +19308,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDTemp8",
@@ -19321,7 +19321,7 @@
     "WINDTemp9": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND2"
             ],
             "id": "WINDTemp9",
@@ -19332,7 +19332,7 @@
         },
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT2"
             ],
             "id": "WINDTemp9",
@@ -19345,7 +19345,7 @@
     "WIND_ALT_TEMP": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT1"
             ],
             "id": "WIND_ALT_TEMP",
@@ -19358,7 +19358,7 @@
     "WND": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "STRINFO",
                 "WAYPT1"
             ],
@@ -19372,7 +19372,7 @@
     "WNDDIV": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND",
                 "WNDEDIT"
             ],
@@ -19386,7 +19386,7 @@
     "WNDEDIT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "WNDEDIT",
@@ -19399,7 +19399,7 @@
     "WNDEDWindDirection1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT"
             ],
             "id": "WNDEDWindDirection1",
@@ -19412,7 +19412,7 @@
     "WNDEDWindDirection2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT"
             ],
             "id": "WNDEDWindDirection2",
@@ -19425,7 +19425,7 @@
     "WNDEDWindSpeed1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT"
             ],
             "id": "WNDEDWindSpeed1",
@@ -19438,7 +19438,7 @@
     "WNDEDWindSpeed2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WNDEDIT"
             ],
             "id": "WNDEDWindSpeed2",
@@ -19451,7 +19451,7 @@
     "WNDWindDirection1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "WNDWindDirection1",
@@ -19464,7 +19464,7 @@
     "WNDWindDirection2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "WNDWindDirection2",
@@ -19477,7 +19477,7 @@
     "WNDWindSpeed1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "WNDWindSpeed1",
@@ -19490,7 +19490,7 @@
     "WNDWindSpeed2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WIND"
             ],
             "id": "WNDWindSpeed2",
@@ -19503,7 +19503,7 @@
     "WPActive": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPActive",
@@ -19516,7 +19516,7 @@
     "WPActive1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPActive1",
@@ -19529,7 +19529,7 @@
     "WPActive2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPActive2",
@@ -19542,7 +19542,7 @@
     "WPActive3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPActive3",
@@ -19555,7 +19555,7 @@
     "WPActive4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPActive4",
@@ -19568,7 +19568,7 @@
     "WPActive5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPActive5",
@@ -19581,7 +19581,7 @@
     "WPActive6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPActive6",
@@ -19594,7 +19594,7 @@
     "WPActive7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPActive7",
@@ -19607,7 +19607,7 @@
     "WPFPNumber": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPFPNumber",
@@ -19620,7 +19620,7 @@
     "WPFPNumber1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPFPNumber1",
@@ -19633,7 +19633,7 @@
     "WPFPNumber2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPFPNumber2",
@@ -19646,7 +19646,7 @@
     "WPInput": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPInput",
@@ -19659,7 +19659,7 @@
     "WPInput1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPInput1",
@@ -19672,7 +19672,7 @@
     "WPInput2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPInput2",
@@ -19685,7 +19685,7 @@
     "WPN_EVENTS": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "WPN_EVENTS",
@@ -19698,7 +19698,7 @@
     "WPN_EVENTS1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "WPN_EVENTS1",
@@ -19711,7 +19711,7 @@
     "WPName": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPName",
@@ -19724,7 +19724,7 @@
     "WPName1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPName1",
@@ -19737,7 +19737,7 @@
     "WPName2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPName2",
@@ -19750,7 +19750,7 @@
     "WPName3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPName3",
@@ -19763,7 +19763,7 @@
     "WPName4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPName4",
@@ -19776,7 +19776,7 @@
     "WPName5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPName5",
@@ -19789,7 +19789,7 @@
     "WPName6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPName6",
@@ -19802,7 +19802,7 @@
     "WPName7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPName7",
@@ -19815,7 +19815,7 @@
     "WPNewName": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPNewName",
@@ -19828,7 +19828,7 @@
     "WPNewName1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPNewName1",
@@ -19841,7 +19841,7 @@
     "WPNewName2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPNewName2",
@@ -19854,7 +19854,7 @@
     "WPNewName3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPNewName3",
@@ -19867,7 +19867,7 @@
     "WPNewName4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPNewName4",
@@ -19880,7 +19880,7 @@
     "WPNewName5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPNewName5",
@@ -19893,7 +19893,7 @@
     "WPNumber": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPNumber",
@@ -19906,7 +19906,7 @@
     "WPNumber1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPNumber1",
@@ -19919,7 +19919,7 @@
     "WPNumber2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPNumber2",
@@ -19932,7 +19932,7 @@
     "WPNumber3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPNumber3",
@@ -19945,7 +19945,7 @@
     "WPNumber4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPNumber4",
@@ -19958,7 +19958,7 @@
     "WPNumber5": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPNumber5",
@@ -19971,7 +19971,7 @@
     "WPNumber6": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPNumber6",
@@ -19984,7 +19984,7 @@
     "WPNumber7": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPNumber7",
@@ -19997,7 +19997,7 @@
     "WPT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT",
                 "WAYPT2"
             ],
@@ -20011,7 +20011,7 @@
     "WPTATT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPTATT",
@@ -20024,7 +20024,7 @@
     "WPTATTBranch": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPTATTBranch",
@@ -20037,7 +20037,7 @@
     "WPTATTBranch1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPTATTBranch1",
@@ -20050,7 +20050,7 @@
     "WPTATTBranch2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "FPBUILD"
             ],
             "id": "WPTATTBranch2",
@@ -20063,7 +20063,7 @@
     "WPTATTScale": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATTScale",
@@ -20076,7 +20076,7 @@
     "WPTATTScale1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATTScale1",
@@ -20089,7 +20089,7 @@
     "WPTATTScale2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATTScale2",
@@ -20102,7 +20102,7 @@
     "WPTATTScale3": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATTScale3",
@@ -20115,7 +20115,7 @@
     "WPTATTScale4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATTScale4",
@@ -20128,7 +20128,7 @@
     "WPTATTSteer": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATTSteer",
@@ -20141,7 +20141,7 @@
     "WPTATTSteer1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATTSteer1",
@@ -20154,7 +20154,7 @@
     "WPTATTSteer2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATTSteer2",
@@ -20167,7 +20167,7 @@
     "WPTATTSteer4": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATTSteer4",
@@ -20180,7 +20180,7 @@
     "WPTATTVNavMode": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATTVNavMode",
@@ -20193,7 +20193,7 @@
     "WPTATTVNavMode1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATTVNavMode1",
@@ -20206,7 +20206,7 @@
     "WPTATTVNavMode2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATTVNavMode2",
@@ -20219,7 +20219,7 @@
     "WPTATT_DTOT": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATT_DTOT",
@@ -20232,7 +20232,7 @@
     "WPTATT_DTOT1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATT_DTOT1",
@@ -20245,7 +20245,7 @@
     "WPTATT_DTOT_ST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATT_DTOT_ST",
@@ -20258,7 +20258,7 @@
     "WPTATT_DTTG": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATT_DTTG",
@@ -20271,7 +20271,7 @@
     "WPTATT_DTTG1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATT_DTTG1",
@@ -20284,7 +20284,7 @@
     "WPTATT_DTTG_ST": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATT_DTTG_ST",
@@ -20297,7 +20297,7 @@
     "WPTATT_FP_Number": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATT_FP_Number",
@@ -20310,7 +20310,7 @@
     "WPTATT_WPT_Name": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATT_WPT_Name",
@@ -20323,7 +20323,7 @@
     "WPTATT_WPT_Number": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPTATT"
             ],
             "id": "WPTATT_WPT_Number",
@@ -20336,7 +20336,7 @@
     "WPTDIS1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "WPTDIS1",
@@ -20349,7 +20349,7 @@
     "WPTDIS2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "WPTDIS2",
@@ -20362,7 +20362,7 @@
     "WPTDISMH": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "WPTDISMH",
@@ -20375,7 +20375,7 @@
     "WPTMH1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "WPTMH1",
@@ -20388,7 +20388,7 @@
     "WPTMH2": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "WPTMH2",
@@ -20401,7 +20401,7 @@
     "WPTTTG1": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "WPTTTG1",
@@ -20414,7 +20414,7 @@
     "WPTTTG2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "WPTTTG2",
@@ -20427,7 +20427,7 @@
     "WPTTTG3": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "WPINFO"
             ],
             "id": "WPTTTG3",
@@ -20440,7 +20440,7 @@
     "WRITE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "MXLOG"
             ],
             "id": "WRITE",
@@ -20453,7 +20453,7 @@
     "YEAR": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "YEAR",
@@ -20466,7 +20466,7 @@
     "YEAR_DE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "YEAR_DE",
@@ -20479,7 +20479,7 @@
     "YEAR_TXT": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "TIME"
             ],
             "id": "YEAR_TXT",
@@ -20492,7 +20492,7 @@
     "YES": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "LASTE"
             ],
             "id": "YES",
@@ -20505,7 +20505,7 @@
     "ZEROES1": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "SYS2"
             ],
             "id": "ZEROES1",
@@ -20518,7 +20518,7 @@
     "ZEROES2": [
         {
             "alignment": "RGHT",
-            "cdu_pages": [
+            "pages": [
                 "SYS2"
             ],
             "id": "ZEROES2",
@@ -20531,7 +20531,7 @@
     "ZEROIZE": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSKEYS"
             ],
             "id": "ZEROIZE",
@@ -20544,7 +20544,7 @@
     "pName": [
         {
             "alignment": "LFT",
-            "cdu_pages": [
+            "pages": [
                 "GPSSTAT2"
             ],
             "id": "pName",

--- a/Scripts/DCS-BIOS/lib/EUFD.json
+++ b/Scripts/DCS-BIOS/lib/EUFD.json
@@ -1,0 +1,1919 @@
+{
+    "WarningList_1": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "WarningList_1",
+            "staticText": true,
+            "x": 1,
+            "y": 1
+        }
+    ],
+    "WarningList_2": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "WarningList_2",
+            "staticText": true,
+            "x": 1,
+            "y": 2
+        }
+    ],
+    "WarningList_3": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "WarningList_3",
+            "staticText": true,
+            "x": 1,
+            "y": 3
+        }
+    ],
+    "WarningList_4": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "WarningList_4",
+            "staticText": true,
+            "x": 1,
+            "y": 4
+        }
+    ],
+    "WarningList_5": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "WarningList_5",
+            "staticText": true,
+            "x": 1,
+            "y": 5
+        }
+    ],
+    "WarningList_6": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "WarningList_6",
+            "staticText": true,
+            "x": 1,
+            "y": 6
+        }
+    ],
+    "WarningList_7": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "WarningList_7",
+            "staticText": true,
+            "x": 1,
+            "y": 7
+        }
+    ],
+    "Symbols_1": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Symbols_1",
+            "staticText": true,
+            "x": 19,
+            "y": 1
+        }
+    ],
+    "Symbols_2": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Symbols_2",
+            "staticText": true,
+            "x": 19,
+            "y": 2
+        }
+    ],
+    "Symbols_3": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Symbols_3",
+            "staticText": true,
+            "x": 19,
+            "y": 3
+        }
+    ],
+    "Symbols_4": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Symbols_4",
+            "staticText": true,
+            "x": 19,
+            "y": 4
+        }
+    ],
+    "Symbols_5": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Symbols_5",
+            "staticText": true,
+            "x": 19,
+            "y": 5
+        }
+    ],
+    "Arrows_1": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Arrows_1",
+            "staticText": true,
+            "x": 19,
+            "y": 6
+        }
+    ],
+    "Arrows_2": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Arrows_2",
+            "staticText": true,
+            "x": 19,
+            "y": 7
+        }
+    ],
+    "CautionList_1": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "CautionList_1",
+            "staticText": true,
+            "x": 20,
+            "y": 1
+        }
+    ],
+    "CautionList_2": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "CautionList_2",
+            "staticText": true,
+            "x": 20,
+            "y": 2
+        }
+    ],
+    "CautionList_3": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "CautionList_3",
+            "staticText": true,
+            "x": 20,
+            "y": 3
+        }
+    ],
+    "CautionList_4": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "CautionList_4",
+            "staticText": true,
+            "x": 20,
+            "y": 4
+        }
+    ],
+    "CautionList_5": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "CautionList_5",
+            "staticText": true,
+            "x": 20,
+            "y": 5
+        }
+    ],
+    "CautionList_6": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "CautionList_6",
+            "staticText": true,
+            "x": 20,
+            "y": 6
+        }
+    ],
+    "CautionList_7": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "CautionList_7",
+            "staticText": true,
+            "x": 20,
+            "y": 7
+        }
+    ],
+    "Symbols_6": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Symbols_6",
+            "staticText": true,
+            "x": 38,
+            "y": 1
+        },
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Symbols_6",
+            "staticText": true,
+            "x": 19,
+            "y": 6
+        }
+    ],
+    "Symbols_7": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Symbols_7",
+            "staticText": true,
+            "x": 38,
+            "y": 2
+        },
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Symbols_7",
+            "staticText": true,
+            "x": 19,
+            "y": 7
+        }
+    ],
+    "Symbols_8": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Symbols_8",
+            "staticText": true,
+            "x": 38,
+            "y": 3
+        },
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Symbols_8",
+            "staticText": true,
+            "x": 38,
+            "y": 1
+        }
+    ],
+    "Symbols_9": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Symbols_9",
+            "staticText": true,
+            "x": 38,
+            "y": 4
+        },
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Symbols_9",
+            "staticText": true,
+            "x": 38,
+            "y": 2
+        }
+    ],
+    "Symbols_10": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Symbols_10",
+            "staticText": true,
+            "x": 38,
+            "y": 5
+        },
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Symbols_10",
+            "staticText": true,
+            "x": 38,
+            "y": 3
+        }
+    ],
+    "Arrows_3": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Arrows_3",
+            "staticText": true,
+            "x": 38,
+            "y": 6
+        }
+    ],
+    "Arrows_4": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Arrows_4",
+            "staticText": true,
+            "x": 38,
+            "y": 7
+        }
+    ],
+    "AdvisoryList_1": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "AdvisoryList_1",
+            "staticText": true,
+            "x": 39,
+            "y": 1
+        }
+    ],
+    "AdvisoryList_2": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "AdvisoryList_2",
+            "staticText": true,
+            "x": 39,
+            "y": 2
+        }
+    ],
+    "AdvisoryList_3": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "AdvisoryList_3",
+            "staticText": true,
+            "x": 39,
+            "y": 3
+        }
+    ],
+    "AdvisoryList_4": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "AdvisoryList_4",
+            "staticText": true,
+            "x": 39,
+            "y": 4
+        }
+    ],
+    "AdvisoryList_5": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "AdvisoryList_5",
+            "staticText": true,
+            "x": 39,
+            "y": 5
+        }
+    ],
+    "AdvisoryList_6": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "AdvisoryList_6",
+            "staticText": true,
+            "x": 39,
+            "y": 6
+        }
+    ],
+    "AdvisoryList_7": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "AdvisoryList_7",
+            "staticText": true,
+            "x": 39,
+            "y": 7
+        }
+    ],
+    "Idm_VHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Idm_VHF",
+            "staticText": true,
+            "x": 1,
+            "y": 8
+        }
+    ],
+    "Idm_UHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Idm_UHF",
+            "staticText": true,
+            "x": 1,
+            "y": 9
+        }
+    ],
+    "Idm_FM1": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Idm_FM1",
+            "staticText": true,
+            "x": 1,
+            "y": 10
+        }
+    ],
+    "Idm_FM2": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Idm_FM2",
+            "staticText": true,
+            "x": 1,
+            "y": 11
+        }
+    ],
+    "Idm_HF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Idm_HF",
+            "staticText": true,
+            "x": 1,
+            "y": 12
+        }
+    ],
+    "Rts_VHF_": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Rts_VHF_",
+            "staticText": true,
+            "x": 2,
+            "y": 8
+        }
+    ],
+    "Rts_UHF_": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Rts_UHF_",
+            "staticText": true,
+            "x": 2,
+            "y": 9
+        }
+    ],
+    "Rts_FM1_": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Rts_FM1_",
+            "staticText": true,
+            "x": 2,
+            "y": 10
+        }
+    ],
+    "Rts_FM2_": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Rts_FM2_",
+            "staticText": true,
+            "x": 2,
+            "y": 11
+        }
+    ],
+    "Rts_HF_": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Rts_HF_",
+            "staticText": true,
+            "x": 2,
+            "y": 12
+        }
+    ],
+    "Rts__VHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Rts__VHF",
+            "staticText": true,
+            "x": 3,
+            "y": 8
+        }
+    ],
+    "Rts__UHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Rts__UHF",
+            "staticText": true,
+            "x": 3,
+            "y": 9
+        }
+    ],
+    "Rts__FM1": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Rts__FM1",
+            "staticText": true,
+            "x": 3,
+            "y": 10
+        }
+    ],
+    "Rts__FM2": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Rts__FM2",
+            "staticText": true,
+            "x": 3,
+            "y": 11
+        }
+    ],
+    "Rts__HF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Rts__HF",
+            "staticText": true,
+            "x": 3,
+            "y": 12
+        }
+    ],
+    "Radio_VHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Radio_VHF",
+            "staticText": true,
+            "x": 4,
+            "y": 8
+        }
+    ],
+    "Radio_UHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Radio_UHF",
+            "staticText": true,
+            "x": 4,
+            "y": 9
+        }
+    ],
+    "Radio_FM1": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Radio_FM1",
+            "staticText": true,
+            "x": 4,
+            "y": 10
+        }
+    ],
+    "Radio_FM2": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Radio_FM2",
+            "staticText": true,
+            "x": 4,
+            "y": 11
+        }
+    ],
+    "Radio_HF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Radio_HF",
+            "staticText": true,
+            "x": 4,
+            "y": 12
+        }
+    ],
+    "Squelch_VHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Squelch_VHF",
+            "staticText": false,
+            "x": 7,
+            "y": 8
+        }
+    ],
+    "Squelch_UHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Squelch_UHF",
+            "staticText": false,
+            "x": 7,
+            "y": 9
+        }
+    ],
+    "Squelch_FM1": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Squelch_FM1",
+            "staticText": false,
+            "x": 7,
+            "y": 10
+        }
+    ],
+    "Squelch_FM2": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Squelch_FM2",
+            "staticText": false,
+            "x": 7,
+            "y": 11
+        }
+    ],
+    "Squelch_HF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Squelch_HF",
+            "staticText": false,
+            "x": 7,
+            "y": 12
+        }
+    ],
+    "Frequency_VHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Frequency_VHF",
+            "staticText": false,
+            "x": 10,
+            "y": 8
+        }
+    ],
+    "Frequency_UHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Frequency_UHF",
+            "staticText": false,
+            "x": 10,
+            "y": 9
+        }
+    ],
+    "Frequency_FM1": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Frequency_FM1",
+            "staticText": false,
+            "x": 10,
+            "y": 10
+        }
+    ],
+    "Frequency_FM2": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Frequency_FM2",
+            "staticText": false,
+            "x": 10,
+            "y": 11
+        }
+    ],
+    "Frequency_HF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Frequency_HF",
+            "staticText": false,
+            "x": 10,
+            "y": 12
+        }
+    ],
+    "Call_VHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Call_VHF",
+            "staticText": false,
+            "x": 20,
+            "y": 8
+        }
+    ],
+    "Call_UHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Call_UHF",
+            "staticText": false,
+            "x": 20,
+            "y": 9
+        }
+    ],
+    "Call_FM1": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Call_FM1",
+            "staticText": false,
+            "x": 20,
+            "y": 10
+        }
+    ],
+    "Call_FM2": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Call_FM2",
+            "staticText": false,
+            "x": 20,
+            "y": 11
+        }
+    ],
+    "Call_HF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Call_HF",
+            "staticText": false,
+            "x": 20,
+            "y": 12
+        }
+    ],
+    "RadioStats_HF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "RadioStats_HF",
+            "staticText": false,
+            "x": 20,
+            "y": 13
+        }
+    ],
+    "Cipher_UHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Cipher_UHF",
+            "staticText": false,
+            "x": 26,
+            "y": 9
+        }
+    ],
+    "Cipher_FM1": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Cipher_FM1",
+            "staticText": false,
+            "x": 26,
+            "y": 10
+        }
+    ],
+    "Cipher_FM2": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Cipher_FM2",
+            "staticText": false,
+            "x": 26,
+            "y": 11
+        }
+    ],
+    "Cipher_HF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Cipher_HF",
+            "staticText": false,
+            "x": 26,
+            "y": 12
+        }
+    ],
+    "Guard": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Guard",
+            "staticText": true,
+            "x": 29,
+            "y": 9
+        }
+    ],
+    "PowerStatus_FM1": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "PowerStatus_FM1",
+            "staticText": true,
+            "x": 29,
+            "y": 10
+        }
+    ],
+    "PowerStatus_HF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "PowerStatus_HF",
+            "staticText": true,
+            "x": 29,
+            "y": 12
+        }
+    ],
+    "Net_VHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Net_VHF",
+            "staticText": false,
+            "x": 34,
+            "y": 8
+        }
+    ],
+    "Net_UHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Net_UHF",
+            "staticText": false,
+            "x": 34,
+            "y": 9
+        }
+    ],
+    "Net_FM1": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Net_FM1",
+            "staticText": false,
+            "x": 34,
+            "y": 10
+        }
+    ],
+    "Net_FM2": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Net_FM2",
+            "staticText": false,
+            "x": 34,
+            "y": 11
+        }
+    ],
+    "TI_VHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "TI_VHF",
+            "staticText": false,
+            "x": 36,
+            "y": 8
+        }
+    ],
+    "TI_UHF": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "TI_UHF",
+            "staticText": false,
+            "x": 36,
+            "y": 9
+        }
+    ],
+    "TI_FM1": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "TI_FM1",
+            "staticText": false,
+            "x": 36,
+            "y": 10
+        }
+    ],
+    "TI_FM2": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "TI_FM2",
+            "staticText": false,
+            "x": 36,
+            "y": 11
+        }
+    ],
+    "Frequency_Standby_VHF": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Frequency_Standby_VHF",
+            "staticText": false,
+            "x": 39,
+            "y": 8
+        }
+    ],
+    "Frequency_Standby_UHF": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Frequency_Standby_UHF",
+            "staticText": false,
+            "x": 39,
+            "y": 9
+        }
+    ],
+    "Frequency_Standby_FM1": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Frequency_Standby_FM1",
+            "staticText": false,
+            "x": 39,
+            "y": 10
+        }
+    ],
+    "Frequency_Standby_FM2": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Frequency_Standby_FM2",
+            "staticText": false,
+            "x": 39,
+            "y": 11
+        }
+    ],
+    "Frequency_Standby_HF": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Frequency_Standby_HF",
+            "staticText": false,
+            "x": 39,
+            "y": 12
+        }
+    ],
+    "Call_Standby_VHF": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Call_Standby_VHF",
+            "staticText": false,
+            "x": 49,
+            "y": 8
+        }
+    ],
+    "Call_Standby_UHF": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Call_Standby_UHF",
+            "staticText": false,
+            "x": 49,
+            "y": 9
+        }
+    ],
+    "Call_Standby_FM1": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Call_Standby_FM1",
+            "staticText": false,
+            "x": 49,
+            "y": 10
+        }
+    ],
+    "Call_Standby_FM2": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Call_Standby_FM2",
+            "staticText": false,
+            "x": 49,
+            "y": 11
+        }
+    ],
+    "Call_Standby_HF": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Call_Standby_HF",
+            "staticText": false,
+            "x": 49,
+            "y": 12
+        }
+    ],
+    "Net_Standby_VHF": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Net_Standby_VHF",
+            "staticText": false,
+            "x": 55,
+            "y": 8
+        }
+    ],
+    "Net_Standby_UHF": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Net_Standby_UHF",
+            "staticText": false,
+            "x": 55,
+            "y": 9
+        }
+    ],
+    "Net_Standby_FM1": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Net_Standby_FM1",
+            "staticText": false,
+            "x": 55,
+            "y": 10
+        }
+    ],
+    "Net_Standby_FM2": [
+        {
+            "pages": [
+                "MAIN"
+            ],
+            "id": "Net_Standby_FM2",
+            "staticText": false,
+            "x": 55,
+            "y": 11
+        }
+    ],
+    "Fuel": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Fuel",
+            "staticText": true,
+            "x": 1,
+            "y": 14
+        }
+    ],
+    "Fuel_": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Fuel_",
+            "staticText": false,
+            "x": 6,
+            "y": 14
+        }
+    ],
+    "Transponder_ID": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Transponder_ID",
+            "staticText": false,
+            "x": 20,
+            "y": 14
+        }
+    ],
+    "XPNDR_MODE_S": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "XPNDR_MODE_S",
+            "staticText": false,
+            "x": 26,
+            "y": 14
+        }
+    ],
+    "Transponder_MODE_3A": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Transponder_MODE_3A",
+            "staticText": false,
+            "x": 28,
+            "y": 14
+        }
+    ],
+    "XPNDR_MODE_4": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "XPNDR_MODE_4",
+            "staticText": false,
+            "x": 33,
+            "y": 14
+        }
+    ],
+    "Transponder_MC": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Transponder_MC",
+            "staticText": true,
+            "x": 35,
+            "y": 14
+        }
+    ],
+    "StopWatch_": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "StopWatch_",
+            "staticText": false,
+            "x": 47,
+            "y": 13
+        }
+    ],
+    "Watch_": [
+        {
+            "pages": [
+                "MAIN",
+                "PRESET"
+            ],
+            "id": "Watch_",
+            "staticText": false,
+            "x": 47,
+            "y": 14
+        }
+    ],
+    "Preset_NAME": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Preset_NAME",
+            "staticText": true,
+            "x": 39,
+            "y": 1
+        }
+    ],
+    "Selected_0": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Selected_0",
+            "staticText": false,
+            "x": 39,
+            "y": 2
+        }
+    ],
+    "Selected_1": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Selected_1",
+            "staticText": false,
+            "x": 39,
+            "y": 3
+        }
+    ],
+    "Selected_2": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Selected_2",
+            "staticText": false,
+            "x": 39,
+            "y": 4
+        }
+    ],
+    "Selected_3": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Selected_3",
+            "staticText": false,
+            "x": 39,
+            "y": 5
+        }
+    ],
+    "Selected_4": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Selected_4",
+            "staticText": false,
+            "x": 39,
+            "y": 6
+        }
+    ],
+    "Selected_5": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Selected_5",
+            "staticText": false,
+            "x": 39,
+            "y": 7
+        }
+    ],
+    "Selected_6": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Selected_6",
+            "staticText": false,
+            "x": 39,
+            "y": 8
+        }
+    ],
+    "Selected_7": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Selected_7",
+            "staticText": false,
+            "x": 39,
+            "y": 9
+        }
+    ],
+    "Selected_8": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Selected_8",
+            "staticText": false,
+            "x": 39,
+            "y": 10
+        }
+    ],
+    "Selected_9": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Selected_9",
+            "staticText": false,
+            "x": 39,
+            "y": 11
+        }
+    ],
+    "Name_0": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Name_0",
+            "staticText": false,
+            "x": 40,
+            "y": 2
+        }
+    ],
+    "Name_1": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Name_1",
+            "staticText": false,
+            "x": 40,
+            "y": 3
+        }
+    ],
+    "Name_2": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Name_2",
+            "staticText": false,
+            "x": 40,
+            "y": 4
+        }
+    ],
+    "Name_3": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Name_3",
+            "staticText": false,
+            "x": 40,
+            "y": 5
+        }
+    ],
+    "Name_4": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Name_4",
+            "staticText": false,
+            "x": 40,
+            "y": 6
+        }
+    ],
+    "Name_5": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Name_5",
+            "staticText": false,
+            "x": 40,
+            "y": 7
+        }
+    ],
+    "Name_6": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Name_6",
+            "staticText": false,
+            "x": 40,
+            "y": 8
+        }
+    ],
+    "Name_7": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Name_7",
+            "staticText": false,
+            "x": 40,
+            "y": 9
+        }
+    ],
+    "Name_8": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Name_8",
+            "staticText": false,
+            "x": 40,
+            "y": 10
+        }
+    ],
+    "Name_9": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Name_9",
+            "staticText": false,
+            "x": 40,
+            "y": 11
+        }
+    ],
+    "Frequency_0": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Frequency_0",
+            "staticText": false,
+            "x": 49,
+            "y": 2
+        }
+    ],
+    "Frequency_1": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Frequency_1",
+            "staticText": false,
+            "x": 49,
+            "y": 3
+        }
+    ],
+    "Frequency_2": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Frequency_2",
+            "staticText": false,
+            "x": 49,
+            "y": 4
+        }
+    ],
+    "Frequency_3": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Frequency_3",
+            "staticText": false,
+            "x": 49,
+            "y": 5
+        }
+    ],
+    "Frequency_4": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Frequency_4",
+            "staticText": false,
+            "x": 49,
+            "y": 6
+        }
+    ],
+    "Frequency_5": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Frequency_5",
+            "staticText": false,
+            "x": 49,
+            "y": 7
+        }
+    ],
+    "Frequency_6": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Frequency_6",
+            "staticText": false,
+            "x": 49,
+            "y": 8
+        }
+    ],
+    "Frequency_7": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Frequency_7",
+            "staticText": false,
+            "x": 49,
+            "y": 9
+        }
+    ],
+    "Frequency_8": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Frequency_8",
+            "staticText": false,
+            "x": 49,
+            "y": 10
+        }
+    ],
+    "Frequency_9": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Frequency_9",
+            "staticText": false,
+            "x": 49,
+            "y": 11
+        }
+    ],
+    "Symbols_11": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Symbols_11",
+            "staticText": true,
+            "x": 38,
+            "y": 4
+        }
+    ],
+    "Symbols_12": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Symbols_12",
+            "staticText": true,
+            "x": 38,
+            "y": 5
+        }
+    ],
+    "Symbols_13": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Symbols_13",
+            "staticText": true,
+            "x": 38,
+            "y": 6
+        }
+    ],
+    "Symbols_14": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Symbols_14",
+            "staticText": true,
+            "x": 38,
+            "y": 7
+        }
+    ],
+    "Symbols_15": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Symbols_15",
+            "staticText": true,
+            "x": 38,
+            "y": 8
+        }
+    ],
+    "Symbols_16": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Symbols_16",
+            "staticText": true,
+            "x": 38,
+            "y": 9
+        }
+    ],
+    "Symbols_17": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Symbols_17",
+            "staticText": true,
+            "x": 38,
+            "y": 10
+        }
+    ],
+    "Symbols_18": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Symbols_18",
+            "staticText": true,
+            "x": 38,
+            "y": 11
+        }
+    ],
+    "Symbols_19": [
+        {
+            "pages": [
+                "PRESET"
+            ],
+            "id": "Symbols_19",
+            "staticText": true,
+            "x": 39,
+            "y": 12
+        }
+    ],
+    "Test_1": [
+        {
+            "pages": [
+                "TEST"
+            ],
+            "id": "Test_1",
+            "staticText": true,
+            "x": 1,
+            "y": 1
+        }
+    ],
+    "Test_2": [
+        {
+            "pages": [
+                "TEST"
+            ],
+            "id": "Test_2",
+            "staticText": true,
+            "x": 1,
+            "y": 2
+        }
+    ],
+    "Test_3": [
+        {
+            "pages": [
+                "TEST"
+            ],
+            "id": "Test_3",
+            "staticText": true,
+            "x": 1,
+            "y": 3
+        }
+    ],
+    "Test_4": [
+        {
+            "pages": [
+                "TEST"
+            ],
+            "id": "Test_4",
+            "staticText": true,
+            "x": 1,
+            "y": 4
+        }
+    ],
+    "Test_5": [
+        {
+            "pages": [
+                "TEST"
+            ],
+            "id": "Test_5",
+            "staticText": true,
+            "x": 1,
+            "y": 5
+        }
+    ],
+    "Test_6": [
+        {
+            "pages": [
+                "TEST"
+            ],
+            "id": "Test_6",
+            "staticText": true,
+            "x": 1,
+            "y": 6
+        }
+    ],
+    "Test_7": [
+        {
+            "pages": [
+                "TEST"
+            ],
+            "id": "Test_7",
+            "staticText": true,
+            "x": 1,
+            "y": 7
+        }
+    ],
+    "Test_8": [
+        {
+            "pages": [
+                "TEST"
+            ],
+            "id": "Test_8",
+            "staticText": true,
+            "x": 1,
+            "y": 8
+        }
+    ],
+    "Test_9": [
+        {
+            "pages": [
+                "TEST"
+            ],
+            "id": "Test_9",
+            "staticText": true,
+            "x": 1,
+            "y": 9
+        }
+    ],
+    "Test_10": [
+        {
+            "pages": [
+                "TEST"
+            ],
+            "id": "Test_10",
+            "staticText": true,
+            "x": 1,
+            "y": 10
+        }
+    ],
+    "Test_11": [
+        {
+            "pages": [
+                "TEST"
+            ],
+            "id": "Test_11",
+            "staticText": true,
+            "x": 1,
+            "y": 11
+        }
+    ],
+    "Test_12": [
+        {
+            "pages": [
+                "TEST"
+            ],
+            "id": "Test_12",
+            "staticText": true,
+            "x": 1,
+            "y": 12
+        }
+    ],
+    "Test_13": [
+        {
+            "pages": [
+                "TEST"
+            ],
+            "id": "Test_13",
+            "staticText": true,
+            "x": 1,
+            "y": 13
+        }
+    ],
+    "Test_14": [
+        {
+            "pages": [
+                "TEST"
+            ],
+            "id": "Test_14",
+            "staticText": true,
+            "x": 1,
+            "y": 14
+        }
+    ]
+}

--- a/Scripts/DCS-BIOS/lib/TextDisplay.lua
+++ b/Scripts/DCS-BIOS/lib/TextDisplay.lua
@@ -1,0 +1,83 @@
+TextDisplay = {}
+
+---Replaces all instances of the keys of the provided map with the values in the provided map
+---@param s string string to replace values in
+---@param map table map of values to replace, where keys are replaced by values
+---@return string s the resulting substituted string
+local function replaceSymbols(s, map)
+    for key, value in pairs(map) do
+        s = s:gsub(key, value)
+    end
+
+    return s
+end
+
+-- this function works by iterating over all of the items in the provided indicatordata table and substituting
+-- them in for each line according to their x and y values
+
+---Gets the display lines for a DCS display
+---@param dcsDisplay table The DCS display to parse
+---@param width number The character width of the screen
+---@param height number The lines of text the screen supports
+---@param displayIndicatorData table The data from the json file containing information about the display
+---@param getDisplayPage function Gets the current display page
+---@param replaceSymbolMap table Map of symbols to replace from -> to
+---@return table displayLines The lines of the display
+function TextDisplay.GetDisplayLines(dcsDisplay, width, height, displayIndicatorData, getDisplayPage, replaceSymbolMap)
+    local emptyLine = string.rep(" ", width)
+
+    local displayLines = {}
+    for i=1,height do
+        displayLines[i] = emptyLine
+    end
+    if not dcsDisplay then
+        return displayLines
+    end
+
+    local displayPage = getDisplayPage()
+
+    for k, v in pairs(dcsDisplay) do
+        local candidates = displayIndicatorData[k]
+        if candidates then
+            if replaceSymbolMap then
+                v = replaceSymbols(v, replaceSymbolMap)
+            end
+            local render_instructions = nil
+            if #candidates == 1 then
+                render_instructions = candidates[1]
+            else
+                for _, ri in pairs(candidates) do
+                    for _, page in pairs(ri.pages) do
+                        if displayPage == page then
+                            render_instructions = ri
+                            break
+                        end
+                    end
+                end
+            end
+            if render_instructions then
+                local ri = render_instructions
+                local old_line = displayLines[ri.y]
+                local replacements = {}
+                if not ri.alignment or ri.alignment == "LFT" then
+                    for i = 1, v:len(), 1 do
+                        local c = v:sub(i,i)
+                        if c ~= " " then replacements[ri.x + i - 1] = c end
+                    end
+                elseif ri.alignment == "RGHT" then
+                    for i = 1, v:len(), 1 do
+                        local c = v:sub(i,i)
+                        if c ~= " " then replacements[ri.x - (v:len() - i)] = c end
+                    end
+                end
+                local new_line = ""
+                for i = 1, width, 1 do
+                    new_line = new_line .. (replacements[i] or old_line:sub(i,i))
+                end
+                displayLines[ri.y] = new_line
+            end
+        end
+    end
+
+    return displayLines
+end


### PR DESCRIPTION
I don't think this is _perfect_ and there might be ways to do it better. The AH-64D's EUFD has a couple of cases where items aren't quite lined up to a standard grid, but I think this approximates it pretty closely. I plan to add the individual items (e.g. fuel, UHF frequencies, etc) later.

This was largely based on the A-10C's CDU code. A lot of it was reusable here, so it seemed best to just extract that logic in the interest of deduplication.

I tested both the A-10's CDU and the AH-64D's EUFD in various modes and with various input to ensure that everything is working as it is supposed to. The A-10's CDU seems to function exactly as before with no changes.

If the author of the original CDU changes is still around, it would be nice to get their eyes on this.

Known issues (with the EUFD):
 - When opening the preset menu, two of the vertical `|` separators disappear. This seems to be because even though ED claims to be rendering an entirely new page, they're just rendering on top of the existing page and they haven't actually set those separator values in the preset page file (they exist, seems like they just haven't wired them up for some reason).
 - I won't lie, I'm not actually sure _why_ this works currently. The preset page text shouldn't appear if I understand the existing code correctly since I haven't yet found a way to get the current CDU page... but it does anyway I guess 🤷 This will probably need to be tweaked and fixed as ED's development of the module continues.
 
Rendering concessions made:
 - Normally the select cursor for the preset channels renders slightly below what would be index 39, so I'm just rendering it at 39
 - The bar along the bottom of the preset popup window normally renders between what would be indices 38 and 39. I've rounded it up to 39. It also only renders 14 characters which have a larger width instead of 18 or so normal-width characters. I've left that part unchanged.