### PR TITLE
AH-64 - fix engine start switch category

### DIFF
--- a/Scripts/DCS-BIOS/doc/json/AH-64D.json
+++ b/Scripts/DCS-BIOS/doc/json/AH-64D.json
@@ -11954,6 +11954,46 @@
                                                                                           } ],
                                                                       "physical_variant": "push_button"
                                                                },
+                                             "PLT_ENG1_START": {
+                                                                       "category": "PLT Left Console",
+                                                                   "control_type": "3Pos_2Command_Switch_OpenClose",
+                                                                    "description": "Pilot No.1 Engine Start Switch, IGN ORIDE/START",
+                                                                     "identifier": "PLT_ENG1_START",
+                                                                         "inputs": [ {
+                                                                                       "description": "set the switch position",
+                                                                                         "interface": "set_state",
+                                                                                         "max_value": 2
+                                                                                   } ],
+                                                                        "outputs": [ {
+                                                                                           "address": 34560,
+                                                                                       "description": "switch position -- 0 = Down, 1 = Mid ,  2 = UP",
+                                                                                              "mask": 48,
+                                                                                         "max_value": 2,
+                                                                                          "shift_by": 4,
+                                                                                            "suffix": "",
+                                                                                              "type": "integer"
+                                                                                   } ]
+                                                               },
+                                             "PLT_ENG2_START": {
+                                                                       "category": "PLT Left Console",
+                                                                   "control_type": "3Pos_2Command_Switch_OpenClose",
+                                                                    "description": "Pilot No.2 Engine Start Switch, IGN ORIDE/START",
+                                                                     "identifier": "PLT_ENG2_START",
+                                                                         "inputs": [ {
+                                                                                       "description": "set the switch position",
+                                                                                         "interface": "set_state",
+                                                                                         "max_value": 2
+                                                                                   } ],
+                                                                        "outputs": [ {
+                                                                                           "address": 34560,
+                                                                                       "description": "switch position -- 0 = Down, 1 = Mid ,  2 = UP",
+                                                                                              "mask": 192,
+                                                                                         "max_value": 2,
+                                                                                          "shift_by": 6,
+                                                                                            "suffix": "",
+                                                                                              "type": "integer"
+                                                                                   } ]
+                                                               },
                                                "PLT_JETT_BTN": {
                                                                            "api_variant": "momentary_last_position",
                                                                               "category": "PLT Left Console",
@@ -14464,46 +14504,6 @@
                                                         }
                                  },
          "PLT Up-Front Display": {
-                                         "PLT_ENG1_START": {
-                                                                   "category": "PLT Up-Front Display",
-                                                               "control_type": "3Pos_2Command_Switch_OpenClose",
-                                                                "description": "Pilot No.1 Engine Start Switch, IGN ORIDE/START",
-                                                                 "identifier": "PLT_ENG1_START",
-                                                                     "inputs": [ {
-                                                                                   "description": "set the switch position",
-                                                                                     "interface": "set_state",
-                                                                                     "max_value": 2
-                                                                               } ],
-                                                                    "outputs": [ {
-                                                                                       "address": 34560,
-                                                                                   "description": "switch position -- 0 = Down, 1 = Mid ,  2 = UP",
-                                                                                          "mask": 48,
-                                                                                     "max_value": 2,
-                                                                                      "shift_by": 4,
-                                                                                        "suffix": "",
-                                                                                          "type": "integer"
-                                                                               } ]
-                                                           },
-                                         "PLT_ENG2_START": {
-                                                                   "category": "PLT Up-Front Display",
-                                                               "control_type": "3Pos_2Command_Switch_OpenClose",
-                                                                "description": "Pilot No.2 Engine Start Switch, IGN ORIDE/START",
-                                                                 "identifier": "PLT_ENG2_START",
-                                                                     "inputs": [ {
-                                                                                   "description": "set the switch position",
-                                                                                     "interface": "set_state",
-                                                                                     "max_value": 2
-                                                                               } ],
-                                                                    "outputs": [ {
-                                                                                       "address": 34560,
-                                                                                   "description": "switch position -- 0 = Down, 1 = Mid ,  2 = UP",
-                                                                                          "mask": 192,
-                                                                                     "max_value": 2,
-                                                                                      "shift_by": 6,
-                                                                                        "suffix": "",
-                                                                                          "type": "integer"
-                                                                               } ]
-                                                           },
                                            "PLT_EUFD_BRT": {
                                                                    "category": "PLT Up-Front Display",
                                                                "control_type": "limited_dial",

--- a/Scripts/DCS-BIOS/lib/AH-64D.lua
+++ b/Scripts/DCS-BIOS/lib/AH-64D.lua
@@ -566,8 +566,8 @@ define3PosTumb("PLT_ROTOR_BRK", 5, 3001, 314, "PLT Left Console", "Pilot Rotor B
 definePushButton("PLT_APU_BTN", 6, 3001, 400, "PLT Left Console", "Pilot APU Pushbutton")
 defineToggleSwitch("PLT_APU_BTN_CVR", 6, 3002, 4001, "PLT Left Console", "Pilot APU Pushbutton Cover, OPEN/CLOSE")
 definePotentiometer("PLT_PW_LVR_FRIC", 2, 3001, 633, {0, 1}, "PLT Left Console", "Pilot Power Lever Friction Adjustment Lever")
-defineSpringloaded_3_pos_tumb("PLT_ENG1_START", 6, 3004, 3003, 317, "PLT Up-Front Display", "Pilot No.1 Engine Start Switch, IGN ORIDE/START")
-defineSpringloaded_3_pos_tumb("PLT_ENG2_START", 6, 3006, 3005, 318, "PLT Up-Front Display", "Pilot No.2 Engine Start Switch, IGN ORIDE/START")
+defineSpringloaded_3_pos_tumb("PLT_ENG1_START", 6, 3004, 3003, 317, "PLT Left Console", "Pilot No.1 Engine Start Switch, IGN ORIDE/START")
+defineSpringloaded_3_pos_tumb("PLT_ENG2_START", 6, 3006, 3005, 318, "PLT Left Console", "Pilot No.2 Engine Start Switch, IGN ORIDE/START")
 
 definePushButton("CPG_JETT_STORE_LO", 75, 3001, 368, "CPG Left Console", "Gunner L OUTBD Station Select Pushbutton, ARM/SAFE")
 definePushButton("CPG_JETT_STORE_LI", 75, 3002, 369, "CPG Left Console", "Gunner L INBD Station Select Pushbutton, ARM/SAFE")


### PR DESCRIPTION
Engine start switches are on the left console (and next to everything else in the left console category).