### PR TITLE
Add digital display parser and start of arc-210

### DIFF
--- a/Scripts/DCS-BIOS/BIOS.lua
+++ b/Scripts/DCS-BIOS/BIOS.lua
@@ -24,6 +24,7 @@ dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\Protocol.lua]])
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\MetadataEnd.lua]])
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\MetadataStart.lua]])
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\CommonData.lua]])
+dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\DigitalDisplay.lua]])
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\TextDisplay.lua]])
 ----------------------------------------------------------------------------Modules Start------------------------------------
 -- Following text: Example (case sensitive!): -- ID = x, ProperName = <pretty name>

--- a/Scripts/DCS-BIOS/doc/json/A-10C_ARC-210.json
+++ b/Scripts/DCS-BIOS/doc/json/A-10C_ARC-210.json
@@ -56,8 +56,8 @@
                 "TR_PRSET_SATCOM",
                 "TR_PRSET"
             ],
-            "biosId": "ARC210_RT",
-            "description": "RT Mode",
+            "biosId": "ARC210_SELECTED_RT",
+            "description": "Selected RT",
             "type": "TEXT",
             "maxLength": 3,
             "alignment": "RIGHT"
@@ -85,7 +85,7 @@
                 "TR_PRSET_SATCOM"
             ],
             "biosId": "ARC210_FREQ_KHZ",
-            "description": "Main frequency (KHZ)",
+            "description": "Main frequency (kHz)",
             "type": "TEXT",
             "maxLength": 3
         }
@@ -98,7 +98,7 @@
                 "GUARD_243"
             ],
             "biosId": "ARC210_FREQ_MHZ",
-            "description": "Main frequency (MHZ)",
+            "description": "Main frequency (MHz)",
             "type": "TEXT",
             "maxLength": 3
         }
@@ -109,7 +109,7 @@
                 "CUR_FREQ_MOD"
             ],
             "biosId": "ARC210_PREV_MANUAL_FREQ",
-            "description": "Previous frequency",
+            "description": "Previous manual frequency",
             "type": "TEXT",
             "maxLength": 7,
             "alignment": "RIGHT"

--- a/Scripts/DCS-BIOS/doc/json/A-10C_ARC-210.json
+++ b/Scripts/DCS-BIOS/doc/json/A-10C_ARC-210.json
@@ -1,0 +1,353 @@
+{
+    "txt_RT": [
+        {
+            "pages": [
+                "CHG_PRESET",
+                "COMSEC_MENU_BASEBAND_PAGE",
+                "COMSEC_MENU_COMSEC_MODE_PAGE",
+                "COMSEC_MENU_CVSD_PAGE",
+                "COMSEC_MENU_DATA_RATE_ANDVT_PAGE",
+                "COMSEC_MENU_DATA_RATE_ANDVT_PAGE",
+                "COMSEC_MENU_DATA_RATE_KY_58_PAGE",
+                "COMSEC_MENU_DATA_RATE_PAGE",
+                "COMSEC_MENU_DATA_TYPE_PAGE",
+                "COMSEC_MENU_LOS_COMSEC",
+                "COMSEC_MENU_UPDATED",
+                "ECCM_LOAD_TIME",
+                "ECCM_RECV_HOPSET",
+                "ECCM",
+                "GPS_LOADING_TIME",
+                "GPS_TIME_RECIEVED",
+                "GPS_TIME",
+                "GUARD_121",
+                "GUARD_243",
+                "HQ_MENU_HQ_II_FMT_PAGE",
+                "HQ_MENU_HQ_II_FMT",
+                "HQ_MENU_OPER_DATE_PAGE",
+                "HQ_MENU_OPER_DATE",
+                "HQ_MENU_VERIFY_WOD_PAGE",
+                "HQ_MENU_VERIFY_WOD",
+                "HQ_MENU_WOD_REASE_PAGE",
+                "HQ_MENU_WOD_ERASE",
+                "HQ_MENU_WOD_REASED",
+                "HQ_MENU_WOD_LOAD_PAGE",
+                "HQ_MENU_WOD_LOAD",
+                "MENU_BEEP_ENABLE_PAGE",
+                "MENU_BEEP_ENABLE",
+                "MENU_DAMA_CHANNELS_PAGE",
+                "MENU_DAMA_CHANNELS",
+                "MENU_EMCON",
+                "MENU_ENTER_KEY_ENABLE_PAGE",
+                "MENU_ENTER_KEY_ENABLE",
+                "MENU_PRESET_CH_26_30_PAGE",
+                "MENU_PRESET_CH_26_30",
+                "MENU_RADIO_ID_NUMBERS_PAGE",
+                "MENU_RADIO_ID_NUMBERS",
+                "MENU_ROOT",
+                "MENU_SWITCH_TEST_PAGE",
+                "MENU_SWITCH_TEST",
+                "MENU_USER_DATA_PORT_CLOCK_PAGE",
+                "MENU_USER_DATA_PORT_PAGE",
+                "MENU_USER_DATA_SYNC_PAGE",
+                "MENU_USER_DATA_PORT",
+                "TEST_PROGRES",
+                "TEST",
+                "TR_MAN",
+                "TR_PRSET_SATCOM",
+                "TR_PRSET"
+            ],
+            "biosId": "ARC210_RT",
+            "description": "RT Mode",
+            "type": "TEXT",
+            "maxLength": 3,
+            "alignment": "RIGHT"
+        }
+    ],
+    "PREV": [
+        {
+            "pages": [
+                "TR_MAN",
+                "TR_PRSET"
+            ],
+            "biosId": "ARC210_PREV",
+            "description": "Previous label",
+            "type": "TEXT",
+            "maxLength": 4,
+            "alignment": "LEFT"
+        }
+    ],
+    "freq_label_khz": [
+        {
+            "pages": [
+                "CUR_FREQ_MOD",
+                "GUARD_121",
+                "GUARD_243",
+                "TR_PRSET_SATCOM"
+            ],
+            "biosId": "ARC210_FREQ_KHZ",
+            "description": "Main frequency (KHZ)",
+            "type": "TEXT",
+            "maxLength": 3
+        }
+    ],
+    "freq_label_mhz": [
+        {
+            "pages": [
+                "CUR_FREQ_MOD",
+                "GUARD_121",
+                "GUARD_243"
+            ],
+            "biosId": "ARC210_FREQ_MHZ",
+            "description": "Main frequency (MHZ)",
+            "type": "TEXT",
+            "maxLength": 3
+        }
+    ],
+    "prev_manual_freq": [
+        {
+            "pages": [
+                "CUR_FREQ_MOD"
+            ],
+            "biosId": "ARC210_PREV_MANUAL_FREQ",
+            "description": "Previous frequency",
+            "type": "TEXT",
+            "maxLength": 7,
+            "alignment": "RIGHT"
+        }
+    ],
+    "modulation_label": [
+        {
+            "pages": [
+                "CUR_FREQ_MOD"
+            ],
+            "biosId": "ARC210_MODULATION",
+            "description": "Modulation (AM/FM)",
+            "type": "TEXT",
+            "maxLength": 2
+        }
+    ],
+    "dot_mark": [
+        {
+            "pages": [
+                "CUR_FREQ_MOD"
+            ],
+            "biosId": "ARC210_FREQ_DOT_MARK",
+            "description": "Main frequency separator (.)",
+            "type": "TEXT",
+            "maxLength": 1
+        }
+    ],
+    "comsec_mode": [
+        {
+            "pages": [
+                "ECCM",
+                "KY"
+            ],
+            "biosId": "ARC210_COMSEC_MODE",
+            "description": "COMSEC mode",
+            "type": "TEXT",
+            "maxLength": 11,
+            "alignment": "LEFT"
+        }
+    ],
+    "comsec_submode": [
+        {
+            "pages": [
+                "ECCM",
+                "KY"
+            ],
+            "biosId": "ARC210_COMSEC_SUBMODE",
+            "description": "COMSEC submode (PT/CT/CT-TD)",
+            "type": "TEXT",
+            "maxLength": 5,
+            "alignment": "LEFT"
+        }
+    ],
+    "ky_submode_label": [
+        {
+            "pages": [
+                "ECCM",
+                "KY"
+            ],
+            "biosId": "ARC210_KY_SUBMODE",
+            "description": "KY Submode",
+            "type": "TEXT",
+            "maxLength": 1,
+            "alignment": "LEFT"
+        }
+    ],
+    "active_channel": [
+        {
+            "pages": [
+                "CHG_PRESET",
+                "ECCM_LOAD_TIME",
+                "ECCM_RECV_HOPSET",
+                "ECCM_SEND_HOPSET",
+                "TR_PRSET_SATCOM"
+            ],
+            "biosId": "ARC210_ACTIVE_CHANNEL",
+            "description": "Active Channel",
+            "type": "TEXT",
+            "maxLength": 2,
+            "alignment": "RIGHT"
+        },
+        {
+            "pages": [
+                "HQ_MENU_VERIFY_WOD_PAGE"
+            ],
+            "biosId": "ARC210_VERIFY_WOD_ACTIVE_CHANNEL",
+            "description": "Active Channel (WOD Page)",
+            "type": "TEXT",
+            "maxLength": 2,
+            "alignment": "RIGHT"
+        },
+        {
+            "pages": [
+                "TR_PRSET"
+            ],
+            "biosId": "ARC210_TR_PRSET_ACTIVE_CHANNEL",
+            "description": "Active Channel (TR_PRSET Page)",
+            "type": "TEXT",
+            "maxLength": 2,
+            "alignment": "RIGHT"
+        }
+    ],
+    "xmit_recv_label": [
+        {
+            "pages": [
+                "CHG_PRESET"
+            ],
+            "biosId": "ARC210_XMIT_RECV",
+            "description": "Transmit/Receive (XMIT/RECV)",
+            "type": "TEXT",
+            "maxLength": 4
+        }
+    ],
+    "EXIT/LOAD": [
+        {
+            "pages": [
+                "COMSEC_MENU_BASEBAND_PAGE",
+                "COMSEC_MENU_COMSEC_MODE_PAGE",
+                "COMSEC_MENU_CVSD_PAGE",
+                "COMSEC_MENU_DATA_RATE_ANDVT_PAGE",
+                "COMSEC_MENU_DATA_RATE_KY_58_PAGE",
+                "COMSEC_MENU_DATA_RATE_PAGE",
+                "COMSEC_MENU_DATA_TYPE_PAGE",
+                "MENU_BEEP_ENABLE_PAGE",
+                "MENU_DAMA_CHANNELS_PAGE",
+                "MENU_EMCON",
+                "MENU_ENTER_KEY_ENABLE_PAGE",
+                "MENU_PRESET_CH_26_30_PAGE",
+                "MENU_RADIO_ID_NUMBERS_PAGE",
+                "MENU_USER_DATA_PORT_CLOCK_PAGE",
+                "MENU_USER_DATA_PORT_PAGE",
+                "MENU_USER_DATA_PORT_SYNC_PAGE"
+            ],
+            "biosId": "ARC210_EXIT_LOAD",
+            "description": "EXIT/LOAD",
+            "type": "TEXT",
+            "maxLength": 9
+        }
+    ],
+    "MORE": [
+        {
+            "pages": [
+                "COMSEC_MENU_BASEBAND_PAGE",
+                "COMSEC_MENU_COMSEC_MODE_PAGE",
+                "COMSEC_MENU_CVSD_PAGE",
+                "COMSEC_MENU_DATA_RATE_ANDVT_PAGE",
+                "COMSEC_MENU_DATA_RATE_KY_58_PAGE",
+                "COMSEC_MENU_DATA_RATE_PAGE",
+                "COMSEC_MENU_DATA_TYPE_PAGE",
+                "COMSEC_MENU_LOS_COMSEC",
+                "HQ_MENU_HQ_II_FMT",
+                "HQ_MENU_OPER_DATE",
+                "HQ_MENU_VERIFY_WOD",
+                "HQ_MENU_WOD_ERASE",
+                "HQ_MENU_WOD_LOAD",
+                "MENU_BEEP_ENABLE",
+                "MENU_DAMA_CHANNELS",
+                "MENU_ENTER_KEY_ENABLE",
+                "MENU_PRESET_CH_26_30",
+                "MENU_RADIO_ID_NUMBERS",
+                "MENU_SWITCH_TEST_PAGE",
+                "MENU_SWITCH_TEST",
+                "MENU_USER_DATA_PORT_CLOCK_PAGE",
+                "MENU_USER_DATA_PORT_PAGE",
+                "MENU_USER_DATA_PORT_SYNC_PAGE",
+                "MENU_USER_DATA_PORT"
+            ],
+            "biosId": "ARC210_MORE",
+            "description": "More",
+            "type": "TEXT",
+            "maxLength": 4
+        }
+    ],
+    "ky_label": [
+        {
+            "pages": [
+                "COMSEC_MENU_UPDATED"
+            ],
+            "biosId": "ARC210_COMSEC_MENU_MODE",
+            "description": "COMSEC menu mode (LOS/DAMA)",
+            "type": "TEXT",
+            "maxLength": 30
+        }
+    ],
+    "LOAD\nTIME": [
+        {
+            "pages": [
+                "ECCM_LOAD_TIME"
+            ],
+            "biosId": "ARC210_LOAD_TIME",
+            "description": "Load Time",
+            "type": "TEXT",
+            "maxLength": 9
+        }
+    ],
+    "SG_time": [
+        {
+            "pages": [
+                "ECCM_LOAD_TIME"
+            ],
+            "biosId": "ARC210_SG_TIME",
+            "description": "SG Time",
+            "type": "TEXT",
+            "maxLength": 5
+        }
+    ],
+    "EXIT/RECV": [
+        {
+            "pages": [
+                "ECCM_RECV_HOPSET"
+            ],
+            "biosId": "ARC210_EXIT_RECV",
+            "description": "EXIT/RECV",
+            "type": "TEXT",
+            "maxLength": 9
+        }
+    ],
+    "EXIT/SEND": [
+        {
+            "pages": [
+                "ECCM_SEND_HOPSET"
+            ],
+            "biosId": "ARC210_EXIT_SEND",
+            "description": "EXIT/SEND",
+            "type": "TEXT",
+            "maxLength": 9
+        }
+    ],
+    "active_eccm_channel_index": [
+        {
+            "pages": [
+                "ECCM"
+            ],
+            "biosId": "ARC210_ACTIVE_ECCM_CHANNEL",
+            "description": "Active ECCM Channel",
+            "type": "TEXT",
+            "maxLength": 2,
+            "alignment": "RIGHT"
+        }
+    ]
+}

--- a/Scripts/DCS-BIOS/lib/DigitalDisplay.lua
+++ b/Scripts/DCS-BIOS/lib/DigitalDisplay.lua
@@ -1,0 +1,81 @@
+DigitalDisplay = {}
+
+---Replaces all instances of the keys of the provided map with the values in the provided map
+---@param s string string to replace values in
+---@param map table map of values to replace, where keys are replaced by values
+---@return string s the resulting substituted string
+local function replaceSymbols(s, map)
+    for key, value in pairs(map) do
+        s = s:gsub(key, value)
+    end
+
+    return s
+end
+
+---Gets the display lines for a DCS display
+---@param dcsDisplay table The DCS display to parse
+---@param displayIndicatorData table The data from the json file containing information about the display
+---@param getDisplayPage function Gets the current display page
+---@param replaceSymbolMap table Map of symbols to replace from -> to
+---@return table displayLines The lines of the display (bios id -> txt)
+function DigitalDisplay.GetDisplayItems(dcsDisplay, displayIndicatorData, getDisplayPage, replaceSymbolMap)
+    local displayLines = {}
+
+    local displayPage = nil
+    if getDisplayPage then
+         displayPage = getDisplayPage()
+    end
+
+    for k, v in pairs(dcsDisplay) do
+        -- "k": {
+        --     "pages": [
+        --         "MAIN" // list of pages that this item can appear on
+        --     ],
+        --     "biosId": "ARC210_COMSEC_MODE", // bios id to use
+        --     "description": "COMSEC Mode", // the name/description displayed in the reference tool
+        --     "maxLength": 11, // max length of the string
+        --     "alignment": "LEFT" // optional alignment for string padding (LEFT, RIGHT, CENTER)
+        --     "type": "TEXT" // the type of the item, which indicates how it should be parsed and generated
+        -- },
+        local candidates = displayIndicatorData[k]
+        if candidates then
+            local render_instructions = nil
+            if displayPage then
+                for _, ri in pairs(candidates) do
+                    for _, page in pairs(ri.pages) do
+                        if displayPage == page then
+                            render_instructions = ri
+                            break
+                        end
+                    end
+                end
+            else
+                render_instructions = candidates[1]
+            end
+            if render_instructions then
+                if replaceSymbolMap then
+                    v = replaceSymbols(v, replaceSymbolMap)
+                end
+                local ri = render_instructions
+                if (ri.type == "TEXT") then
+                    local txt = v;
+                    local max_len = ri.maxLength
+                    txt = v:sub(1, max_len)
+
+                    if ri.alignment == "LEFT" then
+                        txt = txt .. string.rep(" ", max_len - #txt)
+                    elseif ri.alignment == "RIGHT" then
+                        txt = string.rep(" ", max_len - #txt) .. txt
+                    elseif ri.alignment == "CENTER" then
+                        local half = #txt/2
+                        txt = string.rep(" ", max_len - math.floor(half)) .. txt .. string.rep(" ", max_len - math.ceil(half))
+                    end
+
+                    displayLines[ri.biosId] = txt
+                end
+            end
+        end
+    end
+
+    return displayLines
+end


### PR DESCRIPTION
I've addeda new json file similar to the CDU for handling this. Items are defined like so:
```json
"comsec_mode": [
    {
        "pages": [
            "ECCM","KY"
        ],
        "biosId": "ARC210_COMSEC_MODE",
        "description": "COMSEC mode",
        "type": "TEXT",
        "maxLength": 11,
        "alignment": "LEFT"
    }
],
```

the key (`comsec_mode`) is the id as defined in the A-10 luas. These are located in `Cockpit/Scripts/ARC_210/Indicator` and come in a few forms:
- `active_eccm_channel_type.name = "active_eccm_channel_type"`
- `AddTextLabel("LOAD", ...)`
- `AddTempSettingLabel(...)` (this one assigns a random guid, not sure what to do about it)

The `pages` relate to the pages the command exists in. Some exist in more than one page, and they aren't always in the same location - in that case, I add another entry to the array and a new bios id (see `active_channel` as an example). Without a way to get the active page though, this just won't work.

`biosId` is our own id that will be generated for bios. I've been prefixing them with `ARC210` but we can do whatever here.

`description` is the name/description that appears in the reference tool for the item.

`type` is pretty much always going to be `TEXT`, but I'd like to use this for the hornet IFEI as well which has bitmap elements/textures, and this could be expanded to DDIs too.

`maxLength` is the length of the string for bios. This is also used for padding in conjunction with `alignment`.

`alignment` is an optional field which will determine where padding is added if the string is below the max value. This can be `LEFT`, `RIGHT`, or `CENTER`.

I've done the pages alphabetically but stopped at the top of `ECCM`.