### PR TITLE
Fix for the "attempt to concatenate local 'identifier' (a nil value)" issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Scripts/DCS-BIOS/doc/developerguide.adoc
+++ b/Scripts/DCS-BIOS/doc/developerguide.adoc
@@ -221,8 +221,6 @@ document {
     address = tacanTestLEDState.address,
     mask = tacanTestLEDState.mask,
     shift_by = tacanTestLEDState.shiftBy,
-    address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, "BATTERY_POWER"),
-    address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, "BATTERY_POWER") .. "_ADDR",
     max_value = 1,
     description = "1 if light is on, 0 if light is off"
   }

--- a/Scripts/DCS-BIOS/doc/developerguide.html
+++ b/Scripts/DCS-BIOS/doc/developerguide.html
@@ -926,8 +926,6 @@ document {
     address = tacanTestLEDState.address,
     mask = tacanTestLEDState.mask,
     shift_by = tacanTestLEDState.shiftBy,
-	address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, "BATTERY_POWER"),
-	address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, "BATTERY_POWER") .. "_ADDR",
     max_value = 1,
     description = "1 if light is on, 0 if light is off"
   }

--- a/Scripts/DCS-BIOS/lib/A-10C.lua
+++ b/Scripts/DCS-BIOS/lib/A-10C.lua
@@ -171,8 +171,6 @@ document {
 		  address = cmsp1Alloc.address,
 		  mask = cmsp1Alloc.mask,
 		  shift_by = cmsp1Alloc.shiftBy,
-		  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, "CMSP1"),
-		  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, "CMSP1") .. "_ADDR",
 		  max_length = cmsp1Alloc.maxLength,
 		  description = "CMSP Display Line 1 (19 characters)"
 		}
@@ -191,8 +189,6 @@ document {
 		  mask = cmsp2Alloc.mask,
 		  shift_by = cmsp2Alloc.shiftBy,
 		  max_length = cmsp2Alloc.maxLength,
-		  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, "CMSP2"),
-		  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, "CMSP2") .. "_ADDR",
 		  description = "CMSP Display Line 2 (19 characters)"
 		}
 	}
@@ -488,8 +484,6 @@ local function defineCMSPSwitch(msg, device_id, down_command, up_command, arg_nu
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 2,
 			  description = "switch position: 0 - down, 1 - center, 2 - up"
 			}

--- a/Scripts/DCS-BIOS/lib/A-10C.lua
+++ b/Scripts/DCS-BIOS/lib/A-10C.lua
@@ -171,8 +171,8 @@ document {
 		  address = cmsp1Alloc.address,
 		  mask = cmsp1Alloc.mask,
 		  shift_by = cmsp1Alloc.shiftBy,
-		  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-		  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
+		  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, "CMSP1"),
+		  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, "CMSP1") .. "_ADDR",
 		  max_length = cmsp1Alloc.maxLength,
 		  description = "CMSP Display Line 1 (19 characters)"
 		}
@@ -191,8 +191,8 @@ document {
 		  mask = cmsp2Alloc.mask,
 		  shift_by = cmsp2Alloc.shiftBy,
 		  max_length = cmsp2Alloc.maxLength,
-		  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-		  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
+		  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, "CMSP2"),
+		  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, "CMSP2") .. "_ADDR",
 		  description = "CMSP Display Line 2 (19 characters)"
 		}
 	}

--- a/Scripts/DCS-BIOS/lib/AJS37.lua
+++ b/Scripts/DCS-BIOS/lib/AJS37.lua
@@ -46,8 +46,6 @@ local function defineIndicatorLight1(msg, arg_number, category, description)
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "Afterburner Stage Light 1"
 			}
@@ -79,8 +77,6 @@ local function defineIndicatorLight2(msg, arg_number, category, description)
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "Afterburner Stage Light 2"
 			}
@@ -112,8 +108,6 @@ local function defineIndicatorLight3(msg, arg_number, category, description)
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "Afterburner Stage Light 3"
 			}

--- a/Scripts/DCS-BIOS/lib/AV8BNA.lua
+++ b/Scripts/DCS-BIOS/lib/AV8BNA.lua
@@ -53,8 +53,6 @@ local function defineAV8BCommSelector(msg, device_id, command, arg_delta, arg_nu
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 65535,
 			  description = "rotation of the knob"
 			}

--- a/Scripts/DCS-BIOS/lib/F-14.lua
+++ b/Scripts/DCS-BIOS/lib/F-14.lua
@@ -48,8 +48,6 @@ local function defineIndicatorLightMulti1(msg, arg_number, category, description
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "Multi Led Color 1; Light is on between 0.4 and 0.59"
 			}
@@ -81,8 +79,6 @@ local function defineIndicatorLightMulti2(msg, arg_number, category, description
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "Multi Led Color 2; Light is on between 0.8 and 0.98"
 			}
@@ -114,8 +110,6 @@ local function defineIndicatorLightLANTTop(msg, arg_number, category, descriptio
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "LANTRIN Led Top; Light is on between 0.24 and 0.48"
 			}
@@ -147,8 +141,6 @@ local function defineIndicatorLightLANT(msg, arg_number, category, description)
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "LANTRIN Led Booth; Light is on between 0.49 and 0.54"
 			}
@@ -180,8 +172,6 @@ local function defineIndicatorLightLANTBottom(msg, arg_number, category, descrip
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "LANTRIN Led Bottom; Light is on between 0.55 and 0.98"
 			}

--- a/Scripts/DCS-BIOS/lib/F-15E.lua
+++ b/Scripts/DCS-BIOS/lib/F-15E.lua
@@ -47,8 +47,6 @@ local function defineIndicatorLightMulti1(msg, arg_number, category, description
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "Multi Led Color 1; Light is on between 0.1 and 0.59"
 			}
@@ -80,8 +78,6 @@ local function defineIndicatorLightMulti2(msg, arg_number, category, description
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "Multi Led Color 2; Light is on between 0.61 and 1"
 			}

--- a/Scripts/DCS-BIOS/lib/FA-18C_hornet.lua
+++ b/Scripts/DCS-BIOS/lib/FA-18C_hornet.lua
@@ -71,8 +71,6 @@ local function defineEmergencyParkingBrake(msg, device_id, emergency_command, pa
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 2,
 			  description = "switch position -- 0 = emergency, 1 = parking, 2 = release"
 			}
@@ -117,8 +115,6 @@ local function defineToggleSwitchToggleOnly2(msg, device_id, command, arg_number
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "switch position -- 0 = off, 1 = on"
 			}
@@ -163,8 +159,6 @@ local function defineMissionComputerSwitch(msg, device_id, mc1_off_command, mc2_
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 2,
 			  description = "switch position -- 0 = 1OFF, 1 = NORM, 2 = 2OFF"
 			}
@@ -206,8 +200,6 @@ local function defineEjectionHandleSwitch(msg, device_id, command, arg_number, c
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "switch position -- 0 = off, 1 = on"
 			}
@@ -244,8 +236,6 @@ local function defineFrequency(msg, id_device_number, category, description)
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 65535,
 			  description = "frequency"
 			}
@@ -322,8 +312,6 @@ local function defineFloatFromUFCChannel(msg, _channel, category, description)
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 65535,
 			  description = "gauge position"
 			}

--- a/Scripts/DCS-BIOS/lib/Ka-50.lua
+++ b/Scripts/DCS-BIOS/lib/Ka-50.lua
@@ -52,8 +52,6 @@ local function definePushButtonLed(msg, arg_number, category, description)
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "0 if light is off, 1 if light is on"
 			}

--- a/Scripts/DCS-BIOS/lib/P-47D.lua
+++ b/Scripts/DCS-BIOS/lib/P-47D.lua
@@ -43,8 +43,6 @@ local function defineIndicatorLightMulti1(msg, arg_number, category, description
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "Light is on below 0.51"
 			}
@@ -76,8 +74,6 @@ local function defineIndicatorLightMulti2(msg, arg_number, category, description
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "Light is on grater than 0.51"
 			}

--- a/Scripts/DCS-BIOS/lib/Util.lua
+++ b/Scripts/DCS-BIOS/lib/Util.lua
@@ -31,6 +31,14 @@ local function document(args)
 	assert(args.category)
 	if not args.category then args.category = "No Category" end
 	if not moduleBeingDefined.documentation[args.category] then moduleBeingDefined.documentation[args.category] = {} end
+	
+	if args.outputs then
+		for _, output in ipairs(args.outputs) do
+			output.address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, args.identifier)
+			output.address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, args.identifier) .. "_ADDR"
+		end
+	end
+
 	moduleBeingDefined.documentation[args.category][args.identifier] = args
 end
 BIOS.util.document = document
@@ -341,8 +349,6 @@ function BIOS.util.defineIndicatorLight(msg, arg_number, category, description)
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "0 if light is off, 1 if light is on"
 			}
@@ -375,8 +381,6 @@ function BIOS.util.defineIndicatorLightInverted(msg, arg_number, category, descr
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "0 if light is off, 1 if light is on"
 			}
@@ -434,8 +438,6 @@ function BIOS.util.definePotentiometer(msg, device_id, command, arg_number, limi
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 65535,
 			  description = "position of the potentiometer"
 			}
@@ -467,8 +469,6 @@ function BIOS.util.defineRotary(msg, device_id, command, arg_number, category, d
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 65535,
 			  description = "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)"
 			}
@@ -504,8 +504,6 @@ function BIOS.util.defineRotaryPlus(msg, device_id, command2, command1, arg_numb
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 65535,
 			  description = "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)"
 			}
@@ -581,8 +579,6 @@ function BIOS.util.defineSetCommandTumb(msg, device_id, command, arg_number, ste
 			  address = enumAlloc.address,
 			  mask = enumAlloc.mask,
 			  shift_by = enumAlloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = max_value,
 			  description = "selector position"
 			}
@@ -686,8 +682,6 @@ function BIOS.util.defineTumb(msg, device_id, command, arg_number, step, limits,
 			  address = enumAlloc.address,
 			  mask = enumAlloc.mask,
 			  shift_by = enumAlloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = max_value,
 			  description = "selector position"
 			}
@@ -826,8 +820,6 @@ function BIOS.util.defineVariableStepTumb(msg, device_id, command, arg_number, m
 			  address = rotationAlloc.address,
 			  mask = rotationAlloc.mask,
 			  shift_by = rotationAlloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 65535,
 			  description = "rotation of the knob (not the value being manipulated!)"
 			}
@@ -861,8 +853,6 @@ function BIOS.util.defineString(msg, getter, maxLength, category, description)
               address = alloc.address,
               mask = alloc.mask,
               shift_by = alloc.shiftBy,
-              address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
               max_length = alloc.maxLength,
               description = description
             }
@@ -891,8 +881,6 @@ function BIOS.util.defineElectricallyHeldSwitch(msg, device_id, pos_command, neg
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "switch position -- 0 = off, 1 = on"
 			}
@@ -933,8 +921,6 @@ function BIOS.util.defineRockerSwitch(msg, device_id, pos_command, pos_stop_comm
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 2,
 			  description = "selector position"
 			}
@@ -1001,8 +987,6 @@ function BIOS.util.defineFloat(msg, arg_number, limits, category, description)
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 65535,
 			  description = "gauge position"
 			}
@@ -1030,8 +1014,6 @@ function BIOS.util.define8BitFloat(msg, arg_number, limits, category, descriptio
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 255,
 			  description = "gauge position"
 			}
@@ -1056,8 +1038,6 @@ function BIOS.util.defineIntegerFromGetter(msg, getter, maxValue, category, desc
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = maxValue,
 			  description = description
 			}
@@ -1100,8 +1080,6 @@ function BIOS.util.defineFloatFromGetter(msg, getter, limits, category, descript
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 65535,
 			  description = description,
 			  value_range = limits
@@ -1129,8 +1107,6 @@ function BIOS.util.define8BitFloatFromGetter(msg, getter, limits, category, desc
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 255,
 			  description = description,
 			  value_range = limits
@@ -1160,8 +1136,6 @@ function BIOS.util.defineDoubleCommandButton(msg, device_id, start_command, stop
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "selector position"
 			}
@@ -1203,8 +1177,6 @@ function BIOS.util.defineMomentaryRockerSwitch(msg, device_id, pos_command, pos_
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 2,
 			  description = "button position"
 			}
@@ -1268,8 +1240,6 @@ function BIOS.util.defineSpringloaded_3PosTumb(msg, device_id, downSwitch, upSwi
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 2,
 			  description = "switch position -- 0 = Down, 1 = Mid,  2 = Up"
 			}
@@ -1318,8 +1288,6 @@ function BIOS.util.defineSpringloaded_2PosTumb(msg, device_id, downSwitch, upSwi
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "switch position -- 0 = Down, 1 = Up"
 			}
@@ -1366,8 +1334,6 @@ function BIOS.util.define3Pos2CommandSwitchA10(msg, device_id, downSwitch, upSwi
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 2,
 			  description = "switch position -- 0 = Down, 1 = Mid ,  2 = UP"
 			}
@@ -1412,8 +1378,6 @@ function BIOS.util.define3Pos2CommandSwitchF5(msg, device_id, pos_command, neg_c
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 2,
 			  description = "selector position -- 0 = Left, 1 = Mid ,  2 = Right"
 			}
@@ -1457,8 +1421,6 @@ function BIOS.util.defineFloatWithValueConversion(msg, arg_number, limits, input
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 65535,
 			  description = "gauge position"
 			}
@@ -1487,8 +1449,6 @@ function BIOS.util.define3PosMossi(msg, device_id, command, arg_number, category
 			  address = alloc.address,
 			  mask = alloc.mask,
 			  shift_by = alloc.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 2,
 			  description = "selector position -- 0 = Left, 1 = Mid ,  2 = Right"
 			}
@@ -1539,8 +1499,6 @@ function BIOS.util.defineIndicatorLight08(msg, arg_number, category, description
 			  address = value.address,
 			  mask = value.mask,
 			  shift_by = value.shiftBy,
-			  address_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg),
-			  address_only_identifier = BIOS.util.addressDefineIdentifier(moduleBeingDefined.name, msg) .. "_ADDR",
 			  max_value = 1,
 			  description = "LED; Light is on between 0.51 and 0.89"
 			}

--- a/Scripts/DCS-BIOS/lib/Util.lua
+++ b/Scripts/DCS-BIOS/lib/Util.lua
@@ -36,12 +36,20 @@ end
 BIOS.util.document = document
 
 function BIOS.util.addressDefineIdentifier(moduleName, identifier)
-    local full_identifier = moduleName .. "_" .. identifier
-    -- Replace all characters that are not A-Z, a-z, 0-9, or _ with _
-    full_identifier = full_identifier:gsub("[^A-Za-z0-9_]", "_")
-    -- Replace successive underscores with a single _
-    full_identifier = full_identifier:gsub("_+", "_")
-    return full_identifier
+	if moduleName == nil then
+		BIOS.log(string.format("Nil module name found for identifier %s", identifier))
+		return "UNKNOWN"
+	end
+	if identifier == nil then
+		BIOS.log(string.format("Nil identifier found in module %s", moduleName))
+		return "UNKNOWN"
+	end
+
+	local full_identifier = moduleName .. "_" .. identifier
+	full_identifier = full_identifier:gsub("[^A-Za-z0-9_]", "_") -- Replace all characters that are not A-Z, a-z, 0-9, or _ with _
+	full_identifier = full_identifier:gsub("_+", "_") -- Replace successive underscores with a single _
+
+	return full_identifier
 end
 
 BIOS.util.MemoryMapEntry = {


### PR DESCRIPTION
This PR makes to changes:

- Fixes the https://github.com/DCSFlightpanels/dcs-bios/issues/179 issue.
- Removes the requirement to manually add address documentation everywhere. The required values are added automatically in the document() function instead.