### PR TITLE
Mi24p syntax change

### DIFF
--- a/Scripts/DCS-BIOS/lib/Mi-24P.lua
+++ b/Scripts/DCS-BIOS/lib/Mi-24P.lua
@@ -861,7 +861,9 @@ local function getARCLPLTFrequency()
 	if freq2 == nil then freq2 = "0" end
 	local freq3 = ARC15_FREQ_POS[string.format("%.0f", GetDevice(0):get_argument_value(469)/(1/20))]
 	if freq3 == nil then freq3 = "000" end
-	return  freq1 .. freq2 .. freq3 or "000000"
+    local frequency = freq1 .. freq2 .. freq3
+
+	return  frequency or "000000"
 end
 defineString("PLT_ARC_FREQ_L", getARCLPLTFrequency, 6, "ARC-15 PLT", "PILOT ARC-15 Left Frequency (String)")
 
@@ -872,7 +874,9 @@ local function getARCRPLTFrequency()
 	if freq2 == nil then freq2 = "0" end
 	local freq3 = ARC15_FREQ_POS[string.format("%.0f", GetDevice(0):get_argument_value(466)/(1/20))]
 	if freq3 == nil then freq3 = "000" end
-	return  freq1 .. freq2 .. freq3 or "000000"
+    local frequency = freq1 .. freq2 .. freq3
+	
+    return  frequency or "000000"
 end
 defineString("PLT_ARC_FREQ_R", getARCRPLTFrequency, 6, "ARC-15 PLT", "PILOT ARC-15 Right Frequency (String)")
 
@@ -896,7 +900,9 @@ local function getARCLOPFrequency()
 	if freq2 == nil then freq2 = "0" end
 	local freq3 = ARC15_FREQ_POS[string.format("%.0f", GetDevice(0):get_argument_value(641)/(1/20))]
 	if freq3 == nil then freq3 = "000" end
-	return  freq1 .. freq2 .. freq3 or "000000"
+    local frequency = freq1 .. freq2 .. freq3
+	
+    return  frequency or "000000"
 end
 defineString("OP_ARC_FREQ_L", getARCLOPFrequency, 6, "ARC-15 OP", "OPERATOR ARC-15 Left Frequency (String)")
 
@@ -906,8 +912,9 @@ local function getARCROPFrequency()
     local freq2 = string.format("%.0f", GetDevice(0):get_argument_value(643)/(1/9))
 	if freq2 == nil then freq2 = "0" end
 	local freq3 = ARC15_FREQ_POS[string.format("%.0f", GetDevice(0):get_argument_value(644)/(1/20))]
-	if freq3 == nil then freq3 = "000" end
-	return  freq1 .. freq2 .. freq3 or "000000"
+	if freq3 == nil then freq3 = "000" end    local frequency = freq1 .. freq2 .. freq3
+	
+    return  frequency or "000000"
 end
 defineString("OP_ARC_FREQ_R", getARCROPFrequency, 6, "ARC-15 OP", "OPERATOR ARC-15 Right Frequency (String)")
 

--- a/Scripts/DCS-BIOS/lib/Mi-24P.lua
+++ b/Scripts/DCS-BIOS/lib/Mi-24P.lua
@@ -912,7 +912,8 @@ local function getARCROPFrequency()
     local freq2 = string.format("%.0f", GetDevice(0):get_argument_value(643)/(1/9))
 	if freq2 == nil then freq2 = "0" end
 	local freq3 = ARC15_FREQ_POS[string.format("%.0f", GetDevice(0):get_argument_value(644)/(1/20))]
-	if freq3 == nil then freq3 = "000" end    local frequency = freq1 .. freq2 .. freq3
+	if freq3 == nil then freq3 = "000" end    
+    local frequency = freq1 .. freq2 .. freq3
 	
     return  frequency or "000000"
 end


### PR DESCRIPTION
Lua inspection signalled this should be changed so as to be evaluated before *or*ing with "000000". Pre lua and post lua shows same data exports in ctrl-ref.exe.

```    
    return  freq1 .. freq2 .. freq3 or "000000"
```
```
    local frequency = freq1 .. freq2 .. freq3
	
    return  frequency or "000000"
```