### PR TITLE
Mi-8MT Frequency parts concatenated to satisfy lua syntax inspection

### DIFF
--- a/Scripts/DCS-BIOS/lib/Mi-8MT.lua
+++ b/Scripts/DCS-BIOS/lib/Mi-8MT.lua
@@ -505,6 +505,7 @@ defineFixedStepTumb("R863_FREQ2", 38, 3007, 158, 0.1, {0, 1}, {-0.1, 0.1}, nil, 
 defineFixedStepTumb("R863_FREQ3", 38, 3008, 159, 0.1, {0, 1}, {-0.1, 0.1}, nil, "R-863", "R-863, 100KHz Rotary Knob")
 defineFixedStepTumb("R863_FREQ4", 38, 3009, 160, 0.25, {0, 1}, {-0.1, 0.1}, nil, "R-863", "R-863, 1KHz Rotary Knob")
 
+local asdasd = 0
 local function getR863Frequency()
     local freq1 = R863_FREQ1_POS[string.format("%.0f", GetDevice(0):get_argument_value(157)*100)]
 	if freq1 == nil then freq1 = "10" end
@@ -524,8 +525,10 @@ local function getR863Frequency()
 	elseif freq4F >= 62.5 and freq4F < 87.5 then freq4 = "75"
 	elseif freq4F >= 87.5                   then freq4 = "00"
 	end
+    
+    local frequency = freq1 .. freq2 .. "." .. freq3 .. freq4
 
-	return  freq1 .. freq2 .. "." .. freq3 .. freq4 or "100.000"
+	return  frequency or "100.000"
 end
 
 defineTumb("R828_PRST_CHAN_SEL", 39, 3001, 735, 0.1, {0, 0.9}, nil, false, "R-828", "R-828, Radio Channel Selector Knob")

--- a/Scripts/DCS-BIOS/lib/Mi-8MT.lua
+++ b/Scripts/DCS-BIOS/lib/Mi-8MT.lua
@@ -505,7 +505,6 @@ defineFixedStepTumb("R863_FREQ2", 38, 3007, 158, 0.1, {0, 1}, {-0.1, 0.1}, nil, 
 defineFixedStepTumb("R863_FREQ3", 38, 3008, 159, 0.1, {0, 1}, {-0.1, 0.1}, nil, "R-863", "R-863, 100KHz Rotary Knob")
 defineFixedStepTumb("R863_FREQ4", 38, 3009, 160, 0.25, {0, 1}, {-0.1, 0.1}, nil, "R-863", "R-863, 1KHz Rotary Knob")
 
-local asdasd = 0
 local function getR863Frequency()
     local freq1 = R863_FREQ1_POS[string.format("%.0f", GetDevice(0):get_argument_value(157)*100)]
 	if freq1 == nil then freq1 = "10" end
@@ -525,7 +524,7 @@ local function getR863Frequency()
 	elseif freq4F >= 62.5 and freq4F < 87.5 then freq4 = "75"
 	elseif freq4F >= 87.5                   then freq4 = "00"
 	end
-    
+
     local frequency = freq1 .. freq2 .. "." .. freq3 .. freq4
 
 	return  frequency or "100.000"


### PR DESCRIPTION
Lua inspection signalled this should be changed so as to be evaluated before *or*ing with "000000". Pre lua and post lua shows same data exports in ctrl-ref.exe.

```    
    return  freq1 .. freq2 .. freq3 or "000000"
```
```
    local frequency = freq1 .. freq2 .. freq3
	
    return  frequency or "000000"
```