### PR TITLE
Add stylua vscode configuration and github workflow

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,20 @@
+name: Validate style
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    name: Validate style
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Stylua check
+        uses: JohnnyMorganz/stylua-action@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.17.0 # pin to a specific version in case of formatting changes
+          # CLI arguments
+          args: --check .

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,2 @@
+[sort_requires]
+enabled = true

--- a/.styluaignore
+++ b/.styluaignore
@@ -1,0 +1,17 @@
+# exclude everything by default
+/*
+
+# opt-in new code through a series of exclusions and inclusions https://stackoverflow.com/questions/5533050/
+!.styluaignore
+!.stylua.toml
+!/Scripts
+/Scripts/*
+!/Scripts/DCS-BIOS
+/Scripts/DCS-BIOS/*
+!/Scripts/DCS-BIOS/lib
+/Scripts/DCS-BIOS/lib/*
+!/Scripts/DCS-BIOS/lib/modules
+!/Scripts/DCS-BIOS/lib/io
+
+# opt-in test code
+!/Scripts/DCS-BIOS/test

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "johnnymorganz.stylua"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "editor.formatOnSave": true,
+    "[lua]": {
+        "editor.defaultFormatter": "JohnnyMorganz.stylua"
+    },
+    "stylua.targetReleaseVersion": "v0.17.0"
+}


### PR DESCRIPTION
This adds stylua for vs-code users and enables it only for the newly-created files in my recent PRs. Existing files will be unaffected. This also adds a github workflow which will run on commit to validate that the style within these new files conforms to stylua's settings. In the future, this workflow can be used to block PRs which don't meet the style specification if desired (or not).

When opening the workspace in vscode, you will be prompted to install the stylua plugin if you haven't already. Once installed, the workspace is configured to format files on save, so no further action is needed to ensure all necessary files meet style spec!