### PR TITLE
#114 Hack around missing EGI1 page

### DIFF
--- a/Scripts/DCS-BIOS/doc/json/A-10C_CDU.json
+++ b/Scripts/DCS-BIOS/doc/json/A-10C_CDU.json
@@ -12542,6 +12542,19 @@
             "y": 4
         }
     ],
+    "PAGE_NUMBER": [
+        {
+            "alignment": "LFT",
+            "pages": [
+                "EGI1"
+            ],
+            "id": "PAGE_NUMBER",
+            "index": 0,
+            "statictext": true,
+            "x": 19,
+            "y": 10
+        }
+    ],
     "PageFPBUILD": [
         {
             "alignment": "RGHT",

--- a/Scripts/DCS-BIOS/lib/A-10C.lua
+++ b/Scripts/DCS-BIOS/lib/A-10C.lua
@@ -1149,8 +1149,12 @@ local replaceMap = {
     ["я"] = string.char(0xB1),
 }
 
+--- Gets the current CDU page, or nil if one isn't found
+--- @return string page_name the name of the current CDU page
 local function getPageName()
-	return list_cockpit_params():match('CDU_PAGE:"([0-9A-Za-z_]+)"'):sub(5)
+	local page = list_cockpit_params():match('CDU_PAGE:"([0-9A-Za-z_]+)"')
+	if not page then return "EGI1" end -- special case due to ED bug that results in nil being exported instead of EGI1
+	return page:sub(5)
 end
 
 local CDU_LINE_LEN = 24


### PR DESCRIPTION
ED has a bug in the A-10 lua that improperly exports the EGI1 page as nil. This handles that in the page fetcher and returns EGI1 if the page is nil. It's a bit of a hack, but as long as they haven't messed it up in this way with any _other_ pages (and I don't think they have, as far as I can tell), we'll be fine.

This also adds the `PAGE_NUMBER` text which was missing.