### PR TITLE
#151 Fix simshaker incompatibility

### DIFF
--- a/Scripts/DCS-BIOS/lib/Util.lua
+++ b/Scripts/DCS-BIOS/lib/Util.lua
@@ -164,7 +164,7 @@ function BIOS.util.StringAllocation:setValue(value)
 	local i = 1
 
         if value == nil then
-		BIOS.log(string.format("Util.lua: item %s is sending a nil value", msg or "nil"))
+		BIOS.log(string.format("Util.lua: item is sending a nil value"))
 		return
         end
 


### PR DESCRIPTION
Removes attempt to stringify a global variable which is never set (but can be set by other plugins). SimShaker had a table stored in a global variable `msg` for some reason, and when `setValue()` was called with a`nil` argument (which happens sometimes in the A-10, though that may be a separate issue) it attempted to format the table as a string, which is not supported.