### PR TITLE
MiG-29A: Remove emergency control pannel section

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/MiG-29A.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/MiG-29A.lua
@@ -161,8 +161,6 @@ MiG_29A:defineToggleSwitch("OXYGEN_CABIN_EMERGENCY_DECOMPRESSION_SWITCH", device
 
 -- Air conditionning
 
--- Emergency control pannel
-
 -- Flaps controls
 
 -- R-862 VHF / UHF control pannel


### PR DESCRIPTION
Fixes https://github.com/DCS-Skunkworks/dcs-bios/issues/1329

The whole panel is not implemented yet.