### PR TITLE
MiG-29A: IAS indicator

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/MiG-29A.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/MiG-29A.lua
@@ -297,13 +297,7 @@ local unit_metric = nil
 
 MiG_29A:addExportHook(function(dev0)
 	if unit_metric == nil then
-		local val = dev0:get_argument_value(1)
-
-		if val >= 0.01 then
-			unit_metric = false
-		else
-			unit_metric = true
-		end
+		unit_metric = dev0:get_argument_value(1) < 0.01
 	end
 end)
 


### PR DESCRIPTION
Added new defineMultiUnitFloat that handles pulling the correct arg for the gauge depending if the user has the imperial or metric unit in the settings.

Made the variable unitSystem accessible to the whole module as it may be useful to know the value in other controls.