### PR TITLE
FA-18C: Fix shifted addresses from #1507

### DIFF
--- a/Scripts/DCS-BIOS/doc/Addresses.h
+++ b/Scripts/DCS-BIOS/doc/Addresses.h
@@ -10016,8 +10016,6 @@
 #define FA_18C_hornet_APU_READY_LT_AM 0x74C2, 0x0800
 #define FA_18C_hornet_ARRESTING_HOOK_LT 0x74A0, 0x0400, 10
 #define FA_18C_hornet_ARRESTING_HOOK_LT_AM 0x74A0, 0x0400
-#define FA_18C_hornet_HUD_ATC_NWS_ENGAGED 0x74D8, 0x0400, 10
-#define FA_18C_hornet_HUD_ATC_NWS_ENGAGED_AM 0x74D8, 0x0400
 #define FA_18C_hornet_AUX_REL_SW 0x7488, 0x0800, 11
 #define FA_18C_hornet_AUX_REL_SW_AM 0x7488, 0x0800
 #define FA_18C_hornet_AV_COOL_SW 0x74A0, 0x4000, 14
@@ -10162,8 +10160,8 @@
 #define FA_18C_hornet_EXT_FORMATION_LIGHTS_A 0x7576
 #define FA_18C_hornet_EXT_HOOK 0x7586, 0xFFFF, 0
 #define FA_18C_hornet_EXT_HOOK_A 0x7586
-#define FA_18C_hornet_EXT_LAUNCH_BAR 0x7588, 0xFFFF, 0
-#define FA_18C_hornet_EXT_LAUNCH_BAR_A 0x7588
+#define FA_18C_hornet_EXT_LAUNCH_BAR 0x75AE, 0xFFFF, 0
+#define FA_18C_hornet_EXT_LAUNCH_BAR_A 0x75AE
 #define FA_18C_hornet_EXT_NOZZLE_POS_L 0x757A, 0xFFFF, 0
 #define FA_18C_hornet_EXT_NOZZLE_POS_L_A 0x757A
 #define FA_18C_hornet_EXT_NOZZLE_POS_R 0x7578, 0xFFFF, 0
@@ -10259,6 +10257,7 @@
 #define FA_18C_hornet_HUD_ALT_SW_AM 0x742C, 0x4000
 #define FA_18C_hornet_HUD_AOA_INDEXER 0x745E, 0xFFFF, 0
 #define FA_18C_hornet_HUD_AOA_INDEXER_A 0x745E
+#define FA_18C_hornet_HUD_ATC_NWS_ENGAGED_A 0x75A8
 #define FA_18C_hornet_HUD_ATT_SW 0x742E, 0x0300, 8
 #define FA_18C_hornet_HUD_BALANCE 0x745C, 0xFFFF, 0
 #define FA_18C_hornet_HUD_BALANCE_A 0x745C

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
@@ -961,7 +961,6 @@ FA_18C_hornet:defineString("IFEI_R_TEXTURE", function()
 end, 1, "Integrated Fuel/Engine Indicator (IFEI)", "Right Texture Visible: 1 = yes, 0 = no")
 
 FA_18C_hornet:defineFloatFromDrawArgument("EXT_HOOK", 25, "External Aircraft Model", "Hook Position")
-FA_18C_hornet:defineFloatFromDrawArgument("EXT_LAUNCH_BAR", 85, "External Aircraft Model", "Launch Bar position")
 
 FA_18C_hornet:defineFloat("INT_THROTTLE_LEFT", 104, { 0, 1 }, "Throttle Quadrant", "Left Throttle Position")
 FA_18C_hornet:defineFloat("INT_THROTTLE_RIGHT", 105, { 0, 1 }, "Throttle Quadrant", "Right Throttle Position")
@@ -987,5 +986,7 @@ end, 5, "HUD", "Laser Status")
 FA_18C_hornet:defineString("HUD_ATC_NWS_ENGAGED", function()
 	return Functions.coerce_nil_to_string(hud.NWS_cue)
 end, 6, "HUD", "ATC - NWS Engaged")
+
+FA_18C_hornet:defineFloatFromDrawArgument("EXT_LAUNCH_BAR", 85, "External Aircraft Model", "Launch Bar position")
 
 return FA_18C_hornet


### PR DESCRIPTION
`EXT_LAUNCH_BAR` should not have been added before existing controls - updated position and corresponding Addresses.h