### PR TITLE
C-130J: Automatic Flight Control System Panel

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/C-130J.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/C-130J.lua
@@ -678,6 +678,15 @@ C_130J:defineRockerSwitch("TRIM_WING_RIGHT_LEFT", devices.MECH_INTERFACE, 3091, 
 -- Aerial Delivery Panel
 
 -- Automatic Flight Control System Panel
+local AFCS_PANEL = "Automatic Flight Control System Panel"
+C_130J:definePotentiometer("AFCS_TURN_KNOB", devices.AP_INTERFACE, 3016, 70, { -1, 1 }, AFCS_PANEL, "AFCS Turn Control Knob / Center Detent")
+C_130J:defineRotary("AFCS_PITCH_WHEEL", devices.AP_INTERFACE, 3015, 71, AFCS_PANEL, "AFCS Pitch Control Wheel")
+C_130J:defineToggleSwitch("AFCS_PLT_ENGAGE_SWITCH", devices.AP_INTERFACE, 3011, 52, AFCS_PANEL, "Pilot AFCS Engage Switch")
+C_130J:defineToggleSwitch("AFCS_CPLT_ENGAGE_SWITCH", devices.AP_INTERFACE, 3012, 53, AFCS_PANEL, "Copilot AFCS Engage Switch")
+C_130J:definePushButton("AFCS_PITCH_AXIS_SWITCH", devices.AP_INTERFACE, 3013, 51, AFCS_PANEL, "AFCS Pitch Axis Deselect Switch")
+C_130J:definePushButton("AFCS_LATERAL_AXIS_SWITCH", devices.AP_INTERFACE, 3014, 73, AFCS_PANEL, "AFCS Lateral Axis Deselect Switch")
+C_130J:defineIndicatorLight("AFCS_PITCH_AXIS_SWITCH_LED", 4089, AFCS_PANEL, "AFCS Pitch Axis Deselect Light (Green)")
+C_130J:defineIndicatorLight("AFCS_LATERAL_AXIS_SWITCH_LED", 4090, AFCS_PANEL, "AFCS Lateral Axis Deselect Light (Green)")
 
 -- ARC-210
 


### PR DESCRIPTION
Fixes: #1480 

Questions:
1. `AFCS_PITCH_WHEEL` woking, in cockpit it wraps around so I use `defineRotary`
2. `AFCS_TURN_KNOB` has extra paremeters, but is working fine now.
``` lua
elements["PNT_AFCS_TURN_KNOB_70"] = knob_fixed("AFCS Turn Control Knob / Center Detent", PILOT_AP.afcs_lat_knob, 70, 0.1, devices.AP_INTERFACE, {-1, 1}, true, PILOT_AP.afcs_reset_wheel_lat)
```