### PR TITLE
Core: Split color documentation into separate attribute

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/documentation/Control.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/Control.lua
@@ -10,6 +10,7 @@ module("Control", package.seeall)
 --- @field api_variant ApiVariant? TODO
 --- @field deprecated DeprecatedAttributeDocumentation? whether the control has been deprecated
 --- @field positions string[]? descriptions of each position of the control
+--- @field color string? the color of the led, if any
 local Control = {}
 
 --- TODO
@@ -43,6 +44,7 @@ function Control:new(category, controlType, identifier, description, inputs, out
 	if attributes ~= nil then
 		o.deprecated = attributes.deprecated
 		o.positions = attributes.positions
+		o.color = attributes.color
 	end
 
 	setmetatable(o, self)

--- a/Scripts/DCS-BIOS/lib/modules/documentation/ControlAttributeDocumentation.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/ControlAttributeDocumentation.lua
@@ -5,16 +5,19 @@ local DeprecatedAttributeDocumentation = require("Scripts.DCS-BIOS.lib.modules.d
 --- @class ControlAttributeDocumentation
 --- @field deprecated DeprecatedAttributeDocumentation? whether the control has been deprecated
 --- @field positions string[]? descriptions of each position of the control
+--- @field color string? the color of the light, if any
 local ControlAttributeDocumentation = {}
 
 --- @param deprecated DeprecatedAttributeDocumentation? whether the control has been deprecated
 --- @param positions string[]? descriptions of each position of the control
+--- @param color string? the color of the light, if any
 --- @return ControlAttributeDocumentation
-function ControlAttributeDocumentation:new(deprecated, positions)
+function ControlAttributeDocumentation:new(deprecated, positions, color)
 	--- @type ControlAttributeDocumentation
 	local o = {
 		deprecated = deprecated,
 		positions = positions,
+		color = color,
 	}
 
 	setmetatable(o, self)
@@ -49,7 +52,7 @@ function ControlAttributeDocumentation.from_led_attributes(led_attributes)
 		return nil
 	end
 
-	return ControlAttributeDocumentation:new(DeprecatedAttributeDocumentation.from_attributes(led_attributes.deprecated), { "Off", led_attributes.color })
+	return ControlAttributeDocumentation:new(DeprecatedAttributeDocumentation.from_attributes(led_attributes.deprecated), nil, led_attributes.color)
 end
 
 return ControlAttributeDocumentation


### PR DESCRIPTION
Having actual color information rather than "Off/<color" seems like it could be a bit more useful (see https://github.com/DCS-Skunkworks/Bort/pull/30)
<img width="607" height="298" alt="image" src="https://github.com/user-attachments/assets/ce4fc4b0-f717-4cc3-a4ec-667c2c4dd27e" />
