### PR TITLE
F-16C: Fix incorrect inversion bytes for legacy DED lines

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/F-16C_50.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/F-16C_50.lua
@@ -692,7 +692,7 @@ local function mask_4_char(format_str)
 end
 
 local function legacy_ded_line(line_num)
-	return ded_lines[line_num] .. mask_4_char(ded_formats[line_num])
+	return ded_lines[line_num] .. " " .. mask_4_char(ded_formats[line_num])
 end
 
 -- Add DED Display Lines to data sent across


### PR DESCRIPTION
Fixes #1591

Original DED code had 25-character lines instead of 24. The display only has 24 actual characters of text, and when preserving the legacy behavior the additional 25th character (always a space) was forgotten.