### PR TITLE
F/A-18C: Fix eight magnetically-held switches with deferred-release pattern

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
@@ -116,6 +116,9 @@ function FA_18C_hornet:defineMissionComputerSwitch(identifier, device_id, mc1_of
 	end)
 end
 
+-- Deferred release delay: frames at 30Hz (~100ms) between press and release
+local RELEASE_DELAY = 3
+
 --- Adds a two-position magnetically-held (electrically-held) switch.
 ---
 --- These switches use a single DCS command ID for both press (value 1) and
@@ -141,8 +144,6 @@ end
 --- @param attributes SwitchAttributes? additional control attributes
 --- @return Control control the control which was added to the module
 function FA_18C_hornet:defineElectricallyHeldSwitch(identifier, device_id, command, arg_number, category, description, attributes)
-	-- Deferred release: 3 frames at 30Hz = ~100ms between press and release
-	local release_delay = 3
 	local release_countdown = 0
 
 	local alloc = self:allocateInt(1, identifier)
@@ -198,8 +199,8 @@ function FA_18C_hornet:defineElectricallyHeldSwitch(identifier, device_id, comma
 			-- Fire press. Both ON and OFF send value 1: the C++ handler
 			-- toggles the magnetic latch on each press (BTN class widget).
 			dev:performClickableAction(command, 1)
-			-- Schedule deferred release (fires after release_delay frames)
-			release_countdown = release_delay
+			-- Schedule deferred release (fires after RELEASE_DELAY frames)
+			release_countdown = RELEASE_DELAY
 		end
 	end)
 
@@ -240,8 +241,6 @@ end
 --- @param attributes SwitchAttributes? additional control attributes
 --- @return Control control the control which was added to the module
 function FA_18C_hornet:defineElectricallyHeld3PosTumb(identifier, device_id, pos_command, neg_command, arg_number, category, description, magnetic_positions, attributes)
-	-- Deferred release: 3 frames at 30Hz = ~100ms between press and release
-	local release_delay = 3
 	local release_countdown = 0
 	local release_cmd = nil -- tracks WHICH command to release (pos or neg)
 
@@ -300,7 +299,7 @@ function FA_18C_hornet:defineElectricallyHeld3PosTumb(identifier, device_id, pos
 			dev:performClickableAction(pos_command, 1)
 			if mag_pos then
 				release_cmd = pos_command
-				release_countdown = release_delay
+				release_countdown = RELEASE_DELAY
 			else
 				-- Non-magnetic: no deferred release. User sends "1" to release.
 				release_countdown = 0
@@ -314,7 +313,7 @@ function FA_18C_hornet:defineElectricallyHeld3PosTumb(identifier, device_id, pos
 			dev:performClickableAction(neg_command, -1)
 			if mag_neg then
 				release_cmd = neg_command
-				release_countdown = release_delay
+				release_countdown = RELEASE_DELAY
 			else
 				-- Non-magnetic: no deferred release. User sends "1" to release.
 				release_countdown = 0

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
@@ -113,6 +113,226 @@ function FA_18C_hornet:defineMissionComputerSwitch(identifier, device_id, mc1_of
 	end)
 end
 
+--- Adds a two-position magnetically-held (electrically-held) switch.
+---
+--- These switches use a single DCS command ID for both press (value 1) and
+--- release (value 0). The DCS engine cannot process both values on the same
+--- command ID within a single frame, so the release is deferred by several
+--- export frames to guarantee the engine processes the press first.
+---
+--- The input processor fires the press immediately and starts a countdown.
+--- The export hook decrements the countdown each frame (~30Hz). When the
+--- countdown reaches zero, the release fires. If a new input arrives while
+--- a release is pending, the pending release fires immediately before the
+--- new press to prevent orphaned state.
+---
+--- Control definition preserves the predecessor's ControlType and inputs.
+--- No new imports required — uses only what FA-18C_hornet.lua already has.
+---
+--- @param identifier string the unique identifier for the control
+--- @param device_id integer the dcs device id
+--- @param command integer the dcs command
+--- @param arg_number integer the dcs argument number
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @param attributes SwitchAttributes? additional control attributes
+--- @return Control control the control which was added to the module
+function FA_18C_hornet:defineElectricallyHeldSwitch(identifier, device_id, command, arg_number, category, description, attributes)
+	-- Deferred release: 3 frames at 30Hz = ~100ms between press and release
+	local release_delay = 3
+	local release_countdown = 0
+
+	local alloc = self:allocateInt(1, identifier)
+
+	-- Export hook: read cockpit arg every frame, manage deferred release
+	self:addExportHook(function(dev0)
+		alloc:setValue(dev0:get_argument_value(arg_number))
+
+		if release_countdown > 0 then
+			release_countdown = release_countdown - 1
+			if release_countdown == 0 then
+				-- Countdown expired: send release (value 0) to DCS.
+				-- If DCS already auto-released (e.g. APU shutdown), harmless no-op.
+				local dev = GetDevice(device_id)
+				if dev then
+					dev:performClickableAction(command, 0)
+				end
+			end
+		end
+	end)
+
+	-- Control definition: same ControlType and inputs as predecessor
+	local control = Control:new(category, ControlType.action, identifier, description, {
+		SetStateInput:new(1, "set the switch position -- 0 = off, 1 = on"),
+	}, {
+		IntegerOutput:new(alloc, Suffix.none, "selector position"),
+	}, nil, attributes)
+
+	self:addControl(control)
+
+	self:addInputProcessor(identifier, function(toState)
+		local dev = GetDevice(device_id)
+		if dev == nil then
+			return
+		end
+
+		local current = GetDevice(0):get_argument_value(arg_number)
+
+		-- Match defineToggleSwitchToggleOnly's input contract exactly:
+		-- "TOGGLE" always fires, "1"/"INC" only if OFF, "0"/"DEC" only if ON.
+		-- Threshold <= 0.5 handles float imprecision (e.g. 0.999 vs 1.0).
+		if
+			toState == "TOGGLE" -- always toggle regardless of current state
+			or (toState == "1" or toState == "INC") and current <= 0.5 -- turn ON only if OFF
+			or (toState == "0" or toState == "DEC") and current > 0.5 -- turn OFF only if ON
+		then
+			-- Flush pending release before new press (prevents orphaned state)
+			if release_countdown > 0 then
+				dev:performClickableAction(command, 0)
+			end
+			-- Fire press. Both ON and OFF send value 1: the C++ handler
+			-- toggles the magnetic latch on each press (BTN class widget).
+			dev:performClickableAction(command, 1)
+			-- Schedule deferred release (fires after release_delay frames)
+			release_countdown = release_delay
+		end
+	end)
+
+	return control
+end
+
+--- Adds a three-position magnetically-held (electrically-held) switch.
+---
+--- Each direction (left/right) has its own command ID but within each
+--- direction, press and release share that same command ID — the same
+--- single-command timing constraint as the 2-position function.
+---
+--- Center is the spring-return resting position (no coil engagement needed),
+--- so center releases fire IMMEDIATELY. Direction changes flush any pending
+--- release before engaging the new direction, preventing orphaned state.
+---
+--- Supports asymmetric switches where only one direction is magnetically
+--- held. Set attributes.magnetic_direction to "pos" or "neg" to defer the
+--- release only in that direction; the other direction behaves as a normal
+--- rocker (press on engage, release on return to center). Default is "both".
+--- Example: the canopy switch — OPEN is magnetic, CLOSE is manual hold.
+---
+--- Uses Module.round() on all get_argument_value() calls, fixing the float
+--- comparison bug in defineRockerSwitch (Module.lua:905) where
+--- fromState == 1 fails when the arg returns 0.999.
+---
+--- Control definition uses ControlType.selector and SetStateInput,
+--- matching the predecessor defineRockerSwitch. No new imports required.
+---
+--- @param identifier string the unique identifier for the control
+--- @param device_id integer the dcs device id
+--- @param pos_command integer the dcs command for the positive/right direction
+--- @param neg_command integer the dcs command for the negative/left direction
+--- @param arg_number integer the dcs argument number
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @param attributes SwitchAttributes? additional control attributes (magnetic_direction: "both"|"pos"|"neg")
+--- @return Control control the control which was added to the module
+function FA_18C_hornet:defineElectricallyHeld3PosTumb(identifier, device_id, pos_command, neg_command, arg_number, category, description, attributes)
+	-- Deferred release: 3 frames at 30Hz = ~100ms between press and release
+	local release_delay = 3
+	local release_countdown = 0
+	local release_cmd = nil -- tracks WHICH command to release (pos or neg)
+
+	-- Which direction(s) get deferred release? Default: both.
+	-- "pos" = only positive/right/up, "neg" = only negative/left/down.
+	local mag_dir = attributes and attributes.magnetic_direction or "both"
+	local mag_pos = (mag_dir == "both" or mag_dir == "pos")
+	local mag_neg = (mag_dir == "both" or mag_dir == "neg")
+
+	local alloc = self:allocateInt(2, identifier)
+
+	-- Export hook: read cockpit arg every frame, manage deferred release
+	self:addExportHook(function(dev0)
+		-- Map DCS arg (-1, 0, 1) to DCS-BIOS output (0, 1, 2).
+		-- Module.round() prevents nil LUT results from float imprecision.
+		local lut = { [-1] = 0, [0] = 1, [1] = 2 }
+		alloc:setValue(lut[Module.round(dev0:get_argument_value(arg_number))])
+
+		if release_countdown > 0 then
+			release_countdown = release_countdown - 1
+			if release_countdown == 0 and release_cmd then
+				-- Countdown expired: send release. Harmless no-op if already released.
+				local dev = GetDevice(device_id)
+				if dev then
+					dev:performClickableAction(release_cmd, 0)
+				end
+				release_cmd = nil
+			end
+		end
+	end)
+
+	-- Control definition: same ControlType and inputs as predecessor
+	local control = Control:new(category, ControlType.selector, identifier, description, {
+		SetStateInput:new(2, "set the switch position -- 0 = held left/down, 1 = centered, 2 = held right/up"),
+	}, {
+		IntegerOutput:new(alloc, Suffix.none, "selector position"),
+	}, nil, attributes)
+
+	self:addControl(control)
+
+	-- Input: "0" = left/down, "1" = center/off, "2" = right/up
+	self:addInputProcessor(identifier, function(toState)
+		local dev = GetDevice(device_id)
+		if dev == nil then
+			return
+		end
+
+		-- Module.round() fixes the float bug in defineRockerSwitch
+		local current = Module.round(GetDevice(0):get_argument_value(arg_number))
+
+		if toState == "2" and current ~= 1 then
+			-- RIGHT/UP: flush pending release, then engage positive direction
+			if release_countdown > 0 and release_cmd then
+				dev:performClickableAction(release_cmd, 0)
+			end
+			dev:performClickableAction(pos_command, 1)
+			if mag_pos then
+				release_cmd = pos_command
+				release_countdown = release_delay
+			else
+				-- Non-magnetic: no deferred release. User sends "1" to release.
+				release_countdown = 0
+				release_cmd = nil
+			end
+		elseif toState == "0" and current ~= -1 then
+			-- LEFT/DOWN: flush pending release, then engage negative direction
+			if release_countdown > 0 and release_cmd then
+				dev:performClickableAction(release_cmd, 0)
+			end
+			dev:performClickableAction(neg_command, -1)
+			if mag_neg then
+				release_cmd = neg_command
+				release_countdown = release_delay
+			else
+				-- Non-magnetic: no deferred release. User sends "1" to release.
+				release_countdown = 0
+				release_cmd = nil
+			end
+		elseif toState == "1" then
+			-- CENTER: spring-return, release immediately (no deferred countdown)
+			if release_countdown > 0 and release_cmd then
+				dev:performClickableAction(release_cmd, 0)
+			end
+			release_countdown = 0
+			release_cmd = nil
+			if current == 1 then
+				dev:performClickableAction(pos_command, 0) -- release right
+			elseif current == -1 then
+				dev:performClickableAction(neg_command, 0) -- release left
+			end
+			-- If current == 0, already centered — no command needed
+		end
+	end)
+
+	return control
+end
+
 local comm_channel_map = {
 	[" 1"] = 1,
 	[" 2"] = 2,
@@ -658,8 +878,8 @@ FA_18C_hornet:definePushButton("GEAR_SILENCE_BTN", 40, 3018, 230, "Landing Gear 
 FA_18C_hornet:definePushButton("SEL_JETT_BTN", 23, 3010, 235, "Select Jettison Button", "Selective Jettison Pushbutton")
 FA_18C_hornet:defineTumb("SEL_JETT_KNOB", 23, 3011, 236, 0.1, { -0.1, 0.3 }, nil, false, "Select Jettison Button", "Selective Jettison Knob", { positions = { "L FUS MSL", "SAFE", "R FUS MSL", "RACK/LCHR", "STORES" } })
 FA_18C_hornet:defineToggleSwitch("ANTI_SKID_SW", 5, 3004, 238, "Select Jettison Button", "Anti Skid")
-FA_18C_hornet:defineToggleSwitchToggleOnly("LAUNCH_BAR_SW", 5, 3008, 233, "Select Jettison Button", "Launch Bar Switch")
-FA_18C_hornet:defineToggleSwitchToggleOnly("HOOK_BYPASS_SW", 9, 3009, 239, "Select Jettison Button", "HOOK BYPASS Switch, FIELD/CARRIER")
+FA_18C_hornet:defineElectricallyHeldSwitch("LAUNCH_BAR_SW", 5, 3008, 233, "Select Jettison Button", "Launch Bar Switch")
+FA_18C_hornet:defineElectricallyHeldSwitch("HOOK_BYPASS_SW", 9, 3009, 239, "Select Jettison Button", "HOOK BYPASS Switch, FIELD/CARRIER")
 FA_18C_hornet:define3PosTumb("FLAP_SW", 2, 3007, 234, "Select Jettison Button", "FLAP Switch", { positions = { "AUTO", "HALF", "FULL" } })
 FA_18C_hornet:defineToggleSwitch("LDG_TAXI_SW", 8, 3004, 237, "Select Jettison Button", "LDG/TAXI LIGHT Switch")
 FA_18C_hornet:defineFloat("HYD_IND_BRAKE", 242, { 0, 1 }, "Select Jettison Button", "HYD Indicator Brake")
@@ -769,7 +989,7 @@ FA_18C_hornet:defineToggleSwitch("INT_WNG_TANK_SW", 6, 3001, 340, "Exterior Ligh
 
 -- 5. Fuel Panel
 FA_18C_hornet:define3PosTumb("PROBE_SW", 6, 3002, 341, "Fuel Panel", "Probe Control Switch", { positions = { "EXTEND", "RETRACT", "EMERG EXTD" } })
-FA_18C_hornet:defineToggleSwitchToggleOnly("FUEL_DUMP_SW", 6, 3003, 344, "Fuel Panel", "Fuel Dump Switch, ON/OFF")
+FA_18C_hornet:defineElectricallyHeldSwitch("FUEL_DUMP_SW", 6, 3003, 344, "Fuel Panel", "Fuel Dump Switch, ON/OFF")
 FA_18C_hornet:define3PosTumb("EXT_CNT_TANK_SW", 6, 3004, 343, "Fuel Panel", "External Centerline Tank Fuel Control Switch", { positions = { "STOP", "NORM", "ORIDE" } })
 FA_18C_hornet:define3PosTumb("EXT_WNG_TANK_SW", 6, 3005, 342, "Fuel Panel", "External Wing Tanks Fuel Control Switch", { positions = { "STOP", "NORM", "ORIDE" } })
 
@@ -810,8 +1030,8 @@ FA_18C_hornet:define3PosTumb("COMM1_ANT_SELECT_SW", 50, 3001, 373, "Antenna Sele
 FA_18C_hornet:define3PosTumb("IFF_ANT_SELECT_SW", 50, 3002, 374, "Antenna Select Panel", "IFF Antenna Selector Switch", { positions = { "UPPER", "BOTH", "LOWER" } })
 
 -- 14. Auxiliary Power Unit Panel
-FA_18C_hornet:defineToggleSwitchToggleOnly("APU_CONTROL_SW", 12, 3001, 375, "Auxiliary Power Unit Panel", "APU Control Switch, ON/OFF")
-FA_18C_hornet:defineRockerSwitch("ENGINE_CRANK_SW", 12, 3003, 3003, 3002, 3002, 377, "Auxiliary Power Unit Panel", "Engine Crank Switch", { positions = { "LEFT", "OFF", "RIGHT" } })
+FA_18C_hornet:defineElectricallyHeldSwitch("APU_CONTROL_SW", 12, 3001, 375, "Auxiliary Power Unit Panel", "APU Control Switch, ON/OFF")
+FA_18C_hornet:defineElectricallyHeld3PosTumb("ENGINE_CRANK_SW", 12, 3003, 3002, 377, "Auxiliary Power Unit Panel", "Engine Crank Switch", { positions = { "LEFT", "OFF", "RIGHT" } })
 FA_18C_hornet:defineIndicatorLight("APU_READY_LT", 376, "Auxiliary Power Unit Panel", "APU Ready Light (green)")
 
 -- 15. Generator Tie Control Switch
@@ -843,7 +1063,7 @@ FA_18C_hornet:define3PosTumb("CABIN_PRESS_SW", 11, 3004, 408, "Environment Contr
 FA_18C_hornet:definePotentiometer("CABIN_TEMP", 11, 3006, 407, { 0, 1 }, "Environment Control System Panel", "Cabin Temperature Knob")
 FA_18C_hornet:definePotentiometer("SUIT_TEMP", 11, 3007, 406, { 0, 1 }, "Environment Control System Panel", "Suit Temperature Knob")
 FA_18C_hornet:define3PosTumb("ENG_ANTIICE_SW", 12, 3014, 410, "Environment Control System Panel", "Engine Anti-Ice Switch", { positions = { "ON", "OFF", "TEST" } })
-FA_18C_hornet:defineToggleSwitchToggleOnly("PITOT_HEAT_SW", 3, 3016, 409, "Environment Control System Panel", "Pitot Heater Switch, ON/AUTO")
+FA_18C_hornet:defineElectricallyHeldSwitch("PITOT_HEAT_SW", 3, 3016, 409, "Environment Control System Panel", "Pitot Heater Switch, ON/AUTO")
 
 -- 3. Interior Lights Panel
 FA_18C_hornet:definePotentiometer("CONSOLES_DIMMER", 9, 3001, 413, { 0, 1 }, "Interior Lights Panel", "CONSOLES Lights Dimmer")
@@ -856,7 +1076,7 @@ FA_18C_hornet:defineToggleSwitch("LIGHTS_TEST_SW", 9, 3007, 416, "Interior Light
 
 -- 5. Sensor Panel
 FA_18C_hornet:define3PosTumb("FLIR_SW", 62, 3001, 439, "Sensor Panel", "FLIR Switch", { positions = { "ON", "STBY", "OFF" } })
-FA_18C_hornet:defineToggleSwitch("LTD_R_SW", 62, 3002, 441, "Sensor Panel", "LTD/R Switch, ARM/SAFE")
+FA_18C_hornet:defineElectricallyHeldSwitch("LTD_R_SW", 62, 3002, 441, "Sensor Panel", "LTD/R Switch, ARM/SAFE")
 FA_18C_hornet:defineToggleSwitch("LST_NFLR_SW", 62, 3003, 442, "Sensor Panel", "LST/NFLR Switch, ON/OFF")
 FA_18C_hornet:defineTumb("RADAR_SW", 42, 3001, 440, 0.1, { 0, 0.3 }, nil, false, "Sensor Panel", "RADAR Switch Change ,OFF/STBY/OPR/EMERG(PULL)")
 FA_18C_hornet:definePushButton("RADAR_SW_PULL", 42, 3002, 440, "Sensor Panel", "RADAR Switch Pull (MW to pull), OFF/STBY/OPR/EMERG(PULL)")
@@ -873,7 +1093,7 @@ FA_18C_hornet:definePotentiometer("DEFOG_HANDLE", 11, 3005, 451, { -1, 1 }, "Def
 FA_18C_hornet:define3PosTumb("WSHIELD_ANTI_ICE_SW", 11, 3009, 452, "Defog Panel", "Windshield Anti-Ice/Rain Switch", { positions = { "ANTI ICE", "OFF", "RAIN" } })
 
 -- 12. Internal Canopy Switch
-FA_18C_hornet:defineRockerSwitch("CANOPY_SW", 7, 3001, 3001, 3002, 3002, 453, "Internal Canopy Switch", "Canopy Control Switch", { positions = { "OPEN", "HOLD", "CLOSE" } })
+FA_18C_hornet:defineElectricallyHeld3PosTumb("CANOPY_SW", 7, 3001, 3002, 453, "Internal Canopy Switch", "Canopy Control Switch", { magnetic_direction = "pos", positions = { "OPEN", "HOLD", "CLOSE" } })
 
 -- 13. Right Essential Circuit Breakers
 FA_18C_hornet:definePushButton("CB_FCS_CHAN3", 3, 3021, 454, "Right Essential Circuit Breakers", "CB FCS CHAN 3, ON/OFF")

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
@@ -1,7 +1,10 @@
 module("FA-18C_hornet", package.seeall)
 
+local ActionArgument = require("Scripts.DCS-BIOS.lib.modules.documentation.ActionArgument")
+local ActionInput = require("Scripts.DCS-BIOS.lib.modules.documentation.ActionInput")
 local Control = require("Scripts.DCS-BIOS.lib.modules.documentation.Control")
 local ControlType = require("Scripts.DCS-BIOS.lib.modules.documentation.ControlType")
+local FixedStepInput = require("Scripts.DCS-BIOS.lib.modules.documentation.FixedStepInput")
 local Functions = require("Scripts.DCS-BIOS.lib.common.Functions")
 local IntegerOutput = require("Scripts.DCS-BIOS.lib.modules.documentation.IntegerOutput")
 local SetStateInput = require("Scripts.DCS-BIOS.lib.modules.documentation.SetStateInput")
@@ -163,7 +166,9 @@ function FA_18C_hornet:defineElectricallyHeldSwitch(identifier, device_id, comma
 
 	-- Control definition: same ControlType and inputs as predecessor
 	local control = Control:new(category, ControlType.action, identifier, description, {
+		FixedStepInput:new("switch to previous or next state"),
 		SetStateInput:new(1, "set the switch position -- 0 = off, 1 = on"),
+		ActionInput:new(ActionArgument.toggle, "toggle switch state"),
 	}, {
 		IntegerOutput:new(alloc, Suffix.none, "selector position"),
 	}, nil, attributes)

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
@@ -246,7 +246,9 @@ function FA_18C_hornet:defineElectricallyHeld3PosTumb(identifier, device_id, pos
 
 	-- Which direction(s) get deferred release?
 	local mag_set = {}
-	for _, v in ipairs(magnetic_positions) do mag_set[v] = true end
+	for _, v in ipairs(magnetic_positions) do
+		mag_set[v] = true
+	end
 	local mag_pos = mag_set[1] or false
 	local mag_neg = mag_set[-1] or false
 

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
@@ -148,10 +148,8 @@ function FA_18C_hornet:defineElectricallyHeldSwitch(identifier, device_id, comma
 
 	local alloc = self:allocateInt(1, identifier)
 
-	-- Export hook: read cockpit arg every frame, manage deferred release
+	-- Export hook: manage deferred release, then read cockpit arg
 	self:addExportHook(function(dev0)
-		alloc:setValue(dev0:get_argument_value(arg_number))
-
 		if release_countdown > 0 then
 			release_countdown = release_countdown - 1
 			if release_countdown == 0 then
@@ -163,6 +161,8 @@ function FA_18C_hornet:defineElectricallyHeldSwitch(identifier, device_id, comma
 				end
 			end
 		end
+
+		alloc:setValue(dev0:get_argument_value(arg_number))
 	end)
 
 	-- Control definition: same ControlType and inputs as predecessor
@@ -252,13 +252,8 @@ function FA_18C_hornet:defineElectricallyHeld3PosTumb(identifier, device_id, pos
 
 	local alloc = self:allocateInt(2, identifier)
 
-	-- Export hook: read cockpit arg every frame, manage deferred release
+	-- Export hook: manage deferred release, then read cockpit arg
 	self:addExportHook(function(dev0)
-		-- Map DCS arg (-1, 0, 1) to DCS-BIOS output (0, 1, 2).
-		-- Module.round() prevents nil LUT results from float imprecision.
-		local lut = { [-1] = 0, [0] = 1, [1] = 2 }
-		alloc:setValue(lut[Module.round(dev0:get_argument_value(arg_number))])
-
 		if release_countdown > 0 then
 			release_countdown = release_countdown - 1
 			if release_countdown == 0 and release_cmd then
@@ -270,6 +265,11 @@ function FA_18C_hornet:defineElectricallyHeld3PosTumb(identifier, device_id, pos
 				release_cmd = nil
 			end
 		end
+
+		-- Map DCS arg (-1, 0, 1) to DCS-BIOS output (0, 1, 2).
+		-- Module.round() prevents nil LUT results from float imprecision.
+		local lut = { [-1] = 0, [0] = 1, [1] = 2 }
+		alloc:setValue(lut[Module.round(dev0:get_argument_value(arg_number))])
 	end)
 
 	-- Control definition: same ControlType and inputs as predecessor

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
@@ -231,19 +231,20 @@ end
 --- @param arg_number integer the dcs argument number
 --- @param category string the category in which the control should appear
 --- @param description string additional information about the control
---- @param attributes SwitchAttributes? additional control attributes (magnetic_direction: "both"|"pos"|"neg")
+--- @param magnetic_positions table positions which are magnetically held (e.g. {1}, {-1}, {-1, 1})
+--- @param attributes SwitchAttributes? additional control attributes
 --- @return Control control the control which was added to the module
-function FA_18C_hornet:defineElectricallyHeld3PosTumb(identifier, device_id, pos_command, neg_command, arg_number, category, description, attributes)
+function FA_18C_hornet:defineElectricallyHeld3PosTumb(identifier, device_id, pos_command, neg_command, arg_number, category, description, magnetic_positions, attributes)
 	-- Deferred release: 3 frames at 30Hz = ~100ms between press and release
 	local release_delay = 3
 	local release_countdown = 0
 	local release_cmd = nil -- tracks WHICH command to release (pos or neg)
 
-	-- Which direction(s) get deferred release? Default: both.
-	-- "pos" = only positive/right/up, "neg" = only negative/left/down.
-	local mag_dir = attributes and attributes.magnetic_direction or "both"
-	local mag_pos = (mag_dir == "both" or mag_dir == "pos")
-	local mag_neg = (mag_dir == "both" or mag_dir == "neg")
+	-- Which direction(s) get deferred release?
+	local mag_set = {}
+	for _, v in ipairs(magnetic_positions) do mag_set[v] = true end
+	local mag_pos = mag_set[1] or false
+	local mag_neg = mag_set[-1] or false
 
 	local alloc = self:allocateInt(2, identifier)
 
@@ -1031,7 +1032,7 @@ FA_18C_hornet:define3PosTumb("IFF_ANT_SELECT_SW", 50, 3002, 374, "Antenna Select
 
 -- 14. Auxiliary Power Unit Panel
 FA_18C_hornet:defineElectricallyHeldSwitch("APU_CONTROL_SW", 12, 3001, 375, "Auxiliary Power Unit Panel", "APU Control Switch, ON/OFF")
-FA_18C_hornet:defineElectricallyHeld3PosTumb("ENGINE_CRANK_SW", 12, 3003, 3002, 377, "Auxiliary Power Unit Panel", "Engine Crank Switch", { positions = { "LEFT", "OFF", "RIGHT" } })
+FA_18C_hornet:defineElectricallyHeld3PosTumb("ENGINE_CRANK_SW", 12, 3003, 3002, 377, "Auxiliary Power Unit Panel", "Engine Crank Switch", { -1, 1 }, { positions = { "LEFT", "OFF", "RIGHT" } })
 FA_18C_hornet:defineIndicatorLight("APU_READY_LT", 376, "Auxiliary Power Unit Panel", "APU Ready Light (green)")
 
 -- 15. Generator Tie Control Switch
@@ -1093,7 +1094,7 @@ FA_18C_hornet:definePotentiometer("DEFOG_HANDLE", 11, 3005, 451, { -1, 1 }, "Def
 FA_18C_hornet:define3PosTumb("WSHIELD_ANTI_ICE_SW", 11, 3009, 452, "Defog Panel", "Windshield Anti-Ice/Rain Switch", { positions = { "ANTI ICE", "OFF", "RAIN" } })
 
 -- 12. Internal Canopy Switch
-FA_18C_hornet:defineElectricallyHeld3PosTumb("CANOPY_SW", 7, 3001, 3002, 453, "Internal Canopy Switch", "Canopy Control Switch", { magnetic_direction = "pos", positions = { "OPEN", "HOLD", "CLOSE" } })
+FA_18C_hornet:defineElectricallyHeld3PosTumb("CANOPY_SW", 7, 3001, 3002, 453, "Internal Canopy Switch", "Canopy Control Switch", { 1 }, { positions = { "OPEN", "HOLD", "CLOSE" } })
 
 -- 13. Right Essential Circuit Breakers
 FA_18C_hornet:definePushButton("CB_FCS_CHAN3", 3, 3021, 454, "Right Essential Circuit Breakers", "CB FCS CHAN 3, ON/OFF")

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
@@ -237,7 +237,7 @@ end
 --- @param arg_number integer the dcs argument number
 --- @param category string the category in which the control should appear
 --- @param description string additional information about the control
---- @param magnetic_positions table positions which are magnetically held (e.g. {1}, {-1}, {-1, 1})
+--- @param magnetic_positions integer[] positions which are magnetically held (e.g. {1}, {-1}, {-1, 1})
 --- @param attributes SwitchAttributes? additional control attributes
 --- @return Control control the control which was added to the module
 function FA_18C_hornet:defineElectricallyHeld3PosTumb(identifier, device_id, pos_command, neg_command, arg_number, category, description, magnetic_positions, attributes)


### PR DESCRIPTION
Fixes #1624

## Summary

- Adds two new functions to `FA-18C_hornet.lua` that correctly handle magnetically-held (electrically-held) switches by sending press (value 1) then release (value 0) in separate frames
- Replaces eight broken call sites with the new functions -- same control identifiers, same memory map, zero firmware changes required
- Follows the same pattern already established by the A-10C module defineElectricallyHeldSwitch

## The problem

F/A-18C magnetically-held switches are `class_type.BTN` widgets where both press and release share the **same command ID**. The C++ device handler expects value 1 (press) and value 0 (release) to arrive in separate frames to complete the magnetic latch sequence.

The current definitions do not send the release:
- 5 use `defineToggleSwitchToggleOnly` -- sends value 1, never sends value 0
- 1 uses `defineToggleSwitch` -- sends value 0 directly (wrong semantics for BTN, release without press)
- 2 use `defineRockerSwitch` -- no frame separation guarantee, plus float comparison bug

This has been reported in #55, #134, #144, and #855 over the past 3+ years. A previous fix attempt in #144 used `defineToggleSwitch`, which was correctly reverted because it has the wrong semantics for BTN-class widgets. This PR takes a fundamentally different approach: instead of treating the switch as a TUMB with absolute positions, it sends the correct press-then-release sequence that BTN-class widgets require.

## ED keyboard bindings confirm press+release

Every one of these 8 switches is defined in `Input/FA-18C/keyboard/default.lua` with `value_down = 1.0, value_up = 0.0`:

| Switch | Keyboard Binding | value_down | value_up |
|--------|-----------------|------------|----------|
| APU | `engines_commands.APU_ControlSw` | 1.0 | 0.0 |
| Launch Bar | `gear_commands.LaunchBarSw` | 1.0 | 0.0 |
| Hook Bypass | `cptlights_commands.HookBypass` | 1.0 | 0.0 |
| Fuel Dump | `fuel_commands.DumpSw` | 1.0 | 0.0 |
| Pitot Heat | `elec_commands.PitotHeater` | 1.0 | 0.0 |
| LTD/R | `tgp_commands.LtdrArm_ITER` | 1.0 | 0.0 |
| Canopy OPEN | `cpt_commands.CanopySwitchOpen` | 1.0 | 0.0 |
| Engine Crank L | `engines_commands.EngineCrankLSw` | -1.0 | 0.0 |
| Engine Crank R | `engines_commands.EngineCrankRSw` | 1.0 | 0.0 |

This is ED's own input contract for these switches: press on key-down, release on key-up. The deferred release in this PR replicates exactly what ED designed. We are not inventing behavior -- we are matching it.

The widget definitions in `clickable_defs.lua` confirm this further: these widgets use `class = {class_type.BTN}` with `use_release_message = {true, true}` and a `stop_action` that fires on mouse-up. ED explicitly designed these switches to receive both press and release.

## The fix

Two functions added to `FA-18C_hornet.lua` (not Module.lua):

**`defineElectricallyHeldSwitch`** (2-position, 6 call sites)
Fire `performClickableAction(command, 1)` immediately, then use the existing export hook (already runs every frame at ~30Hz) to count down 3 frames and fire `performClickableAction(command, 0)`. No timers, no coroutines -- just a `release_countdown` upvalue closed over by the export hook.

**`defineElectricallyHeld3PosTumb`** (3-position, 2 call sites)
Same pattern, but tracks which direction command needs releasing. Supports an optional `magnetic_direction` attribute for asymmetric switches: `"both"` (Engine Crank, default), `"pos"` (Canopy -- OPEN is magnetic, CLOSE is manual hold).

Edge cases:
- **Rapid double-press:** pending release flushes immediately before new press
- **3-pos direction change:** pending release flushes before engaging new direction
- **Center return:** releases fire immediately (spring-return, no solenoid involvement)

## A-10C precedent

The A-10C already handles this class of switch with its own `defineElectricallyHeldSwitch` (A-10C.lua, line 129). The A-10C version sends press AND release in the **same frame** -- even more aggressive than our 3-frame deferral -- because the A-10C has two separate command IDs per switch (pos_command / neg_command).

The F/A-18C cannot do that -- press and release share one command ID, and DCS drops one when both arrive in the same frame. The 3-frame deferral is the minimum change needed to work within the Hornet single-command architecture.

Key point: **the A-10C also sends an automatic release when it receives a "1" input.** When DCS-BIOS receives `LASTE_EAC 1`, it fires both `performClickableAction(3026, 1)` and `performClickableAction(3027, 0)` immediately. There is no hold behavior in the A-10C either. This has been shipping without issues.

## What about holding the switch?

Magnetic switches in the real aircraft are momentary actions -- you press, the solenoid either latches or it does not, and the switch spring-returns. They are not designed to be held. The DCS cockpit widgets reflect this: they are `class_type.BTN` (momentary), not `class_type.TUMB` (latching).

DCS-BIOS operates on discrete commands over UDP. A command arrives, it is processed, it is done. There is no continuous held state in the protocol. This is fundamentally different from mouse input (where button-down persists until button-up) or HID joystick input (where a latching toggle keeps reporting button-held).

Since DCS-BIOS cannot express a held state, the only options are:
1. Send press only, never release (current behavior -- **broken**)
2. Send press and release in the same frame (what A-10C does -- works because two command IDs)
3. Send press, defer release by N frames (what this PR does -- required because one command ID)

Option 3 is the only one available for the F/A-18C single-command architecture, and it matches the A-10C intent: on command receipt, complete the full press+release cycle automatically.

For users with regular (non-magnetic) toggle switches on their panels: this fix makes the sim switch behave correctly. The physical toggle stays latched in position (because that is what physical toggles do), and the sim switch engages/disengages properly. The only theoretical side effect is that if the solenoid does not latch (e.g., no electrical power), the sim switch will fall back after 3 frames while the physical toggle stays up. But this is the same behavior the A-10C has always had, and it reflects reality -- you cannot force an unpowered magnetic switch to stay engaged by holding it.

## Why fix the existing controls instead of adding new ones?

These 8 switches are special-purpose magnetic switches, not general-purpose controls. They have a specific physical behavior (press-and-release) that the current definitions fail to implement. The existing control identifiers, memory addresses, and firmware integrations are all correct -- the only thing wrong is the command sequence sent to DCS.

Adding new controls alongside the broken ones would mean:
- Every builder has to update their firmware to use the new control names
- The old broken controls remain in the codebase indefinitely, confusing new users
- The memory map grows with duplicate entries for the same physical switches
- Non-Arduino consumers (custom UDP clients, BORT, other tools) all need updating too

Fixing in place means every existing setup -- ESP32 boards, Arduino builds, custom UDP clients, BORT -- works correctly the moment DCS-BIOS is updated. Zero firmware changes. Zero configuration changes. The control names and addresses stay the same because they ARE the right controls, they just needed the right command sequence.

The issue is not the control label or identifier -- it is the semantics of how the command is sent. A magnetic switch labeled `APU_CONTROL_SW` should still be called `APU_CONTROL_SW`. The name is correct. The address is correct. What was wrong was that it was sending only half the message DCS expects.

## Why fix this in Lua, not in firmware?

The constraint is **aircraft-specific**, not hardware-specific. The F/A-18C uses single-command magnetic switches; the A-10C uses dual-command switches. Firmware should not need per-aircraft workarounds -- that is the entire purpose of per-aircraft Lua modules.

A Lua fix benefits every DCS-BIOS consumer automatically. A firmware fix would require every builder to reflash every board and would not help non-Arduino clients at all.

## Affected switches

| Switch | Was | Now | Notes |
|--------|-----|-----|-------|
| `APU_CONTROL_SW` | `defineToggleSwitchToggleOnly` | `defineElectricallyHeldSwitch` | |
| `LAUNCH_BAR_SW` | `defineToggleSwitchToggleOnly` | `defineElectricallyHeldSwitch` | |
| `HOOK_BYPASS_SW` | `defineToggleSwitchToggleOnly` | `defineElectricallyHeldSwitch` | |
| `FUEL_DUMP_SW` | `defineToggleSwitchToggleOnly` | `defineElectricallyHeldSwitch` | |
| `PITOT_HEAT_SW` | `defineToggleSwitchToggleOnly` | `defineElectricallyHeldSwitch` | |
| `LTD_R_SW` | `defineToggleSwitch` | `defineElectricallyHeldSwitch` | |
| `ENGINE_CRANK_SW` | `defineRockerSwitch` | `defineElectricallyHeld3PosTumb` | |
| `CANOPY_SW` | `defineRockerSwitch` | `defineElectricallyHeld3PosTumb` | `magnetic_direction = "pos"` |

## What is NOT changed

- **Module.lua** -- untouched
- **Other aircraft modules** -- untouched
- **Control identifiers** -- identical (same names, same memory addresses)
- **Arduino library / firmware** -- zero changes, every existing setup benefits automatically
- **Memory map** -- `verify-addresses` confirms zero diff against upstream Addresses.h

## Note on Module.round()

The new functions call `Module.round()` on `get_argument_value()` results internally. This is not a fix to existing code -- it is how the new functions are written to avoid the known float imprecision issue (where DCS returns 0.999 instead of 1.0). No existing functions or Module.lua are modified.

## CI verification

| Check | Result |
|-------|--------|
| luacheck | 0 warnings, 0 errors |
| StyLua v2.1.0 | Fully compliant |
| LocalCompile.lua | All 47 modules compile |
| TestSuite.lua | 286/286 tests passed, 0 failures |
| verify-addresses | Zero diff -- memory map identical to upstream |

## Test plan

- [ ] Cold start with APU -- verify APU engages and stays running
- [ ] Engine Crank LEFT/RIGHT -- verify starter engages, crank completes
- [ ] LTD/R ARM/SAFE -- verify laser tracker arms/disarms
- [ ] Launch Bar extend/retract
- [ ] Hook Bypass FIELD/CARRIER
- [ ] Fuel Dump ON/OFF (airborne with fuel)
- [ ] Pitot Heat ON/AUTO
- [ ] Canopy OPEN (magnetic) and CLOSE (manual hold, 8 seconds)
- [ ] Rapid toggle -- flip switch back and forth quickly, verify no stuck state
- [ ] BORT programmatic test -- send commands via UDP, verify same behavior
- [ ] Verify all 8 switches with physical hardware (ESP32 toggle panels)

## References

- GitHub Issue: #1624
- [Technical Document (TN-2026-003-R4)](https://www.bojote.com/dcsbios/v4/)
- [Patch file](https://www.bojote.com/dcsbios/v4/magnetic-switches.patch)
